### PR TITLE
Allow only URLs with https protocol during campaign creation

### DIFF
--- a/src/user/views/adsManager/views/advanced/lib/Library.tsx
+++ b/src/user/views/adsManager/views/advanced/lib/Library.tsx
@@ -464,8 +464,7 @@ export function performValidation(context, validationRule, campaign, adSets, ads
                         validations.adSets[adSetIndex].ads[index].targetUrl = {} as any;
                         validations.adSets[adSetIndex].ads[index].targetUrl.valid = false;
                         validations.adSets[adSetIndex].ads[index].targetUrl.errorMessage = `Creative target url is required, please enter a target url for your creative.`;
-                    }
-                    if (!ad.targetUrl?.startsWith("https://")) {
+                    } else if (!ad.targetUrl?.startsWith("https://")) {
                         validations.adSets[adSetIndex].ads[index].targetUrl = {} as any;
                         validations.adSets[adSetIndex].ads[index].targetUrl.valid = false;
                         validations.adSets[adSetIndex].ads[index].targetUrl.errorMessage = `Creative target url must start with https://`;

--- a/src/user/views/adsManager/views/advanced/lib/Library.tsx
+++ b/src/user/views/adsManager/views/advanced/lib/Library.tsx
@@ -465,6 +465,11 @@ export function performValidation(context, validationRule, campaign, adSets, ads
                         validations.adSets[adSetIndex].ads[index].targetUrl.valid = false;
                         validations.adSets[adSetIndex].ads[index].targetUrl.errorMessage = `Creative target url is required, please enter a target url for your creative.`;
                     }
+                    if (!ad.targetUrl?.startsWith("https://")) {
+                        validations.adSets[adSetIndex].ads[index].targetUrl = {} as any;
+                        validations.adSets[adSetIndex].ads[index].targetUrl.valid = false;
+                        validations.adSets[adSetIndex].ads[index].targetUrl.errorMessage = `Creative target url must start with https://`;
+                    }
                 })
             }
         })


### PR DESCRIPTION

![Screenshot 2022-05-18 at 11 18 38](https://user-images.githubusercontent.com/51444/169017112-bf01aefb-cc3b-4d86-929f-a039836d0cb8.png)

^ not totally clear in that screenshot, but the "publish campaign" button *is* disabled.

Longer term there's a much wider overhaul of the validation required as [we've done in the internal dashboard](https://github.com/brave/ads-admin-dashboard/tree/master/src/validation) to make this sensibly testable. But this change addresses the pressing issue. 

Re #607

Note to reviewers: this PR is to put live on the staging environment - you will need to run this locally if you want to explore its behaviour. A subsequent PR will promote from staging to live.