### PR TITLE
validate creative target url

### DIFF
--- a/src/components/List/CustomListItemText.tsx
+++ b/src/components/List/CustomListItemText.tsx
@@ -3,8 +3,8 @@ import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import React from "react";
 
 interface Props {
-  primary: string;
-  secondary: string | React.ReactNode;
+  primary?: string;
+  secondary?: string | React.ReactNode;
   error?: string;
 }
 
@@ -23,7 +23,6 @@ export function CustomListItemText({ primary, secondary, error }: Props) {
   return (
     <ListItem>
       <ListItemText
-        sx={{ mb: 1 }}
         primary={primary}
         secondary={isError ? getError(error) : secondary}
         primaryTypographyProps={{
@@ -32,7 +31,7 @@ export function CustomListItemText({ primary, secondary, error }: Props) {
           color: "grey",
         }}
         secondaryTypographyProps={{
-          marginTop: "4px",
+          marginTop: !!primary ? "4px" : "0",
           fontSize: "18px",
           color: "black",
           p: isError ? 1 : 0,

--- a/src/components/Url/UrlResolver.tsx
+++ b/src/components/Url/UrlResolver.tsx
@@ -1,0 +1,111 @@
+import {
+  Alert,
+  Box,
+  TextField,
+  InputAdornment,
+  CircularProgress,
+  AlertTitle,
+  Tooltip,
+} from "@mui/material";
+import React, { useMemo, useEffect } from "react";
+import _ from "lodash";
+import { useField } from "formik";
+import { useValidateTargetUrlLazyQuery } from "../../graphql/url.generated";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+
+const simpleUrlRegexp = /https:\/\/.+\.[a-zA-Z]{2,}\/?.*/g;
+
+interface Props {
+  name: string;
+  validator: string;
+  label?: string;
+  disabled?: boolean;
+}
+
+export const UrlResolver: React.FC<Props> = ({
+  name,
+  validator,
+  label = "Website URL",
+  disabled = false,
+}) => {
+  const [nameField, nameMeta] = useField(name);
+  const [isValid, isValidMeta, isValidHelper] = useField(validator);
+  const hasError = Boolean(nameMeta.error);
+  const showError = hasError && nameMeta.touched;
+  const [validateUrl, { loading, data, error }] =
+    useValidateTargetUrlLazyQuery();
+  const debouncedValidateUrl = useMemo(
+    () =>
+      _.debounce(
+        (value: string) =>
+          value &&
+          !hasError &&
+          simpleUrlRegexp.test(value) &&
+          validateUrl({
+            variables: {
+              url: value,
+            },
+          }),
+        500
+      ),
+    []
+  );
+
+  const { value } = isValidMeta;
+  const { setValue } = isValidHelper;
+
+  useEffect(() => {
+    if (!disabled) {
+      debouncedValidateUrl.cancel();
+      debouncedValidateUrl(nameMeta.value);
+
+      if (value !== !!data?.validateTargetUrl?.isValid) {
+        setValue(!loading && !!data?.validateTargetUrl?.isValid);
+      }
+    }
+  });
+
+  return (
+    <>
+      <TextField
+        variant="outlined"
+        label={label}
+        margin="normal"
+        fullWidth
+        error={showError}
+        helperText={showError ? nameMeta.error : undefined}
+        color="secondary"
+        autoComplete="off"
+        disabled={disabled}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              {loading && <CircularProgress />}
+              {data && data.validateTargetUrl.isValid && (
+                <Tooltip title="URL is valid">
+                  <CheckCircleOutlineIcon sx={{ color: "#2e7d32" }} />
+                </Tooltip>
+              )}
+            </InputAdornment>
+          ),
+        }}
+        {...nameField}
+      />
+
+      {!!data && (
+        <Box mt={2}>
+          {!data.validateTargetUrl.isValid && (
+            <>
+              {data.validateTargetUrl.errors.map((e) => (
+                <Alert severity="error" sx={{ mb: 1 }}>
+                  <AlertTitle>URL Error</AlertTitle>
+                  {e}
+                </Alert>
+              ))}
+            </>
+          )}
+        </Box>
+      )}
+    </>
+  );
+};

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -107,8 +107,6 @@ export type CreateAdvertiserInput = {
   name: Scalars["String"];
   phone?: InputMaybe<Scalars["String"]>;
   referrer?: InputMaybe<Scalars["String"]>;
-  selfServiceCreate?: InputMaybe<Scalars["Boolean"]>;
-  selfServiceEdit?: InputMaybe<Scalars["Boolean"]>;
   state?: InputMaybe<Scalars["String"]>;
   userId?: InputMaybe<Scalars["String"]>;
 };
@@ -373,8 +371,6 @@ export type UpdateAdvertiserInput = {
   phone?: InputMaybe<Scalars["String"]>;
   publicKey?: InputMaybe<Scalars["String"]>;
   referrer?: InputMaybe<Scalars["String"]>;
-  selfServiceCreate?: InputMaybe<Scalars["Boolean"]>;
-  selfServiceEdit?: InputMaybe<Scalars["Boolean"]>;
   state?: InputMaybe<Scalars["String"]>;
 };
 

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -107,6 +107,8 @@ export type CreateAdvertiserInput = {
   name: Scalars["String"];
   phone?: InputMaybe<Scalars["String"]>;
   referrer?: InputMaybe<Scalars["String"]>;
+  selfServiceCreate?: InputMaybe<Scalars["Boolean"]>;
+  selfServiceEdit?: InputMaybe<Scalars["Boolean"]>;
   state?: InputMaybe<Scalars["String"]>;
   userId?: InputMaybe<Scalars["String"]>;
 };
@@ -371,6 +373,8 @@ export type UpdateAdvertiserInput = {
   phone?: InputMaybe<Scalars["String"]>;
   publicKey?: InputMaybe<Scalars["String"]>;
   referrer?: InputMaybe<Scalars["String"]>;
+  selfServiceCreate?: InputMaybe<Scalars["Boolean"]>;
+  selfServiceEdit?: InputMaybe<Scalars["Boolean"]>;
   state?: InputMaybe<Scalars["String"]>;
 };
 

--- a/src/graphql/url.generated.tsx
+++ b/src/graphql/url.generated.tsx
@@ -1,0 +1,82 @@
+import * as Types from "./types";
+
+import { gql } from "@apollo/client";
+import * as Apollo from "@apollo/client";
+const defaultOptions = {} as const;
+export type ValidateTargetUrlQueryVariables = Types.Exact<{
+  url: Types.Scalars["String"];
+}>;
+
+export type ValidateTargetUrlQuery = {
+  __typename?: "Query";
+  validateTargetUrl: {
+    __typename?: "TargetUrlValidation";
+    errors: Array<string>;
+    isValid: boolean;
+  };
+};
+
+export const ValidateTargetUrlDocument = gql`
+  query validateTargetUrl($url: String!) {
+    validateTargetUrl(targetUrl: $url) {
+      errors
+      isValid
+    }
+  }
+`;
+
+/**
+ * __useValidateTargetUrlQuery__
+ *
+ * To run a query within a React component, call `useValidateTargetUrlQuery` and pass it any options that fit your needs.
+ * When your component renders, `useValidateTargetUrlQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useValidateTargetUrlQuery({
+ *   variables: {
+ *      url: // value for 'url'
+ *   },
+ * });
+ */
+export function useValidateTargetUrlQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    ValidateTargetUrlQuery,
+    ValidateTargetUrlQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ValidateTargetUrlQuery,
+    ValidateTargetUrlQueryVariables
+  >(ValidateTargetUrlDocument, options);
+}
+export function useValidateTargetUrlLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ValidateTargetUrlQuery,
+    ValidateTargetUrlQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ValidateTargetUrlQuery,
+    ValidateTargetUrlQueryVariables
+  >(ValidateTargetUrlDocument, options);
+}
+export type ValidateTargetUrlQueryHookResult = ReturnType<
+  typeof useValidateTargetUrlQuery
+>;
+export type ValidateTargetUrlLazyQueryHookResult = ReturnType<
+  typeof useValidateTargetUrlLazyQuery
+>;
+export type ValidateTargetUrlQueryResult = Apollo.QueryResult<
+  ValidateTargetUrlQuery,
+  ValidateTargetUrlQueryVariables
+>;
+export function refetchValidateTargetUrlQuery(
+  variables: ValidateTargetUrlQueryVariables
+) {
+  return { query: ValidateTargetUrlDocument, variables: variables };
+}

--- a/src/graphql/url.graphql
+++ b/src/graphql/url.graphql
@@ -1,0 +1,6 @@
+query validateTargetUrl($url: String!) {
+  validateTargetUrl(targetUrl: $url) {
+    errors
+    isValid
+  }
+}

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -181,6 +181,7 @@ export function editCampaignValues(campaign: CampaignFragment): CampaignForm {
           targetUrl: c.payloadNotification!.targetUrl,
           title: c.payloadNotification!.title,
           body: c.payloadNotification!.body,
+          targetUrlValid: true,
         };
       }),
       price: adSet.ads?.[0].prices[0].amount || 0,

--- a/src/user/views/adsManager/types/index.ts
+++ b/src/user/views/adsManager/types/index.ts
@@ -62,6 +62,7 @@ export type Creative = {
   title: string;
   body: string;
   targetUrl: string;
+  targetUrlValid?: boolean;
 };
 
 export const initialCampaign: CampaignForm = {

--- a/src/user/views/adsManager/views/advanced/components/ads/AdField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/ads/AdField.tsx
@@ -17,6 +17,7 @@ import {
   Creative,
   initialCreative,
 } from "../../../../types";
+import { UrlResolver } from "../../../../../../../components/Url/UrlResolver";
 
 interface Props {
   index: number;
@@ -124,8 +125,9 @@ function Ad({ adSetIdx, adIdx, isEdit, creative }: AdProps) {
         disabled={isEdit && !!creative.id}
       />
 
-      <FormikTextField
+      <UrlResolver
         name={`adSets.${adSetIdx}.creatives.${adIdx}.targetUrl`}
+        validator={`adSets.${adSetIdx}.creatives.${adIdx}.targetUrlValid`}
         label="Creative Target URL"
         disabled={isEdit && !!creative.id}
       />

--- a/src/user/views/adsManager/views/advanced/components/review/components/AdReview.tsx
+++ b/src/user/views/adsManager/views/advanced/components/review/components/AdReview.tsx
@@ -42,6 +42,7 @@ export function AdReview({ ad, adIdx, error }: Props) {
           secondary={ad.targetUrl}
           error={hasError ? adError.targetUrl : ""}
         />
+        <CustomListItemText error={hasError ? adError.targetUrlValid : ""} />
       </List>
     </>
   );

--- a/src/validation/CampaignSchema.tsx
+++ b/src/validation/CampaignSchema.tsx
@@ -102,6 +102,9 @@ export const CampaignSchema = object().shape({
                 .label("Body")
                 .max(60, "Max 60 Characters")
                 .required("Body is required"),
+              targetUrlValid: boolean().isTrue(
+                "Target URL is either invalid or still validating, please check Ad for more details."
+              ),
               targetUrl: string()
                 .label("Target Url")
                 .required("URL is required")


### PR DESCRIPTION
Validates target url for self service, displays errors below URL if they are present.

Review form asks that the check the ad, as you can get to review form before url finishes validating.