### PR TITLE
fix: make reporting campaign link not reload

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/src/user/campaignList/CampaignList.tsx
+++ b/src/user/campaignList/CampaignList.tsx
@@ -12,7 +12,7 @@ import {
   renderMonetaryAmount,
 } from "components/EnhancedTable/renderers";
 import EditIcon from "@mui/icons-material/Edit";
-import { useHistory } from "react-router-dom";
+import { useHistory, Link as RouterLink } from "react-router-dom";
 import { Status } from "components/Campaigns/Status";
 import { isAfterEndDate } from "util/isAfterEndDate";
 import { CampaignFormat, CampaignSource } from "graphql/types";
@@ -55,16 +55,17 @@ export function CampaignList({ advertiserCampaigns, fromDate }: Props) {
               alignItems="center"
               direction="row"
             >
-              <Link
-                href={
-                  r.state !== "under_review"
-                    ? `/user/main/campaign/${r.id}/analytics/overview`
-                    : undefined
-                }
-                underline="none"
-              >
-                {r.name}
-              </Link>
+              {r.state !== "under_review" ? (
+                <Link
+                  component={RouterLink}
+                  to={`/user/main/campaign/${r.id}/analytics/overview`}
+                  underline="none"
+                >
+                  {r.name}
+                </Link>
+              ) : (
+                r.name
+              )}
               {advertiserCampaigns?.selfServiceEdit &&
                 r.source === CampaignSource.SelfServe &&
                 r.format === CampaignFormat.PushNotification &&


### PR DESCRIPTION
This link was a normal <a href=> which means it forced a full page reload.  Now navigates without relation in the web app. I also changed it so it doesn't show a non-working link when the campaign in not under review.

Also deleted the vscode settings file I apparently accidentally added many months ago...