### PR TITLE
fix: only persist values once the form has been dirtied

### DIFF
--- a/src/form/PersistFormValues.tsx
+++ b/src/form/PersistFormValues.tsx
@@ -27,7 +27,7 @@ export const PersistFormValues = () => {
       localStorage.setItem(values.draftId, JSON.stringify(values));
     }
     setDrafts();
-  }, [values]);
+  }, [values, dirty]);
 
   return null;
 };

--- a/src/form/PersistFormValues.tsx
+++ b/src/form/PersistFormValues.tsx
@@ -3,12 +3,8 @@ import React, { useContext, useEffect } from "react";
 import { CampaignForm } from "user/views/adsManager/types";
 import { DraftContext } from "state/context";
 
-interface Props {
-  id: string;
-}
-
-export const PersistFormValues: React.FC<Props> = ({ id }) => {
-  const { values, setValues } = useFormikContext<CampaignForm>();
+export const PersistFormValues = () => {
+  const { values, setValues, dirty } = useFormikContext<CampaignForm>();
   const { setDrafts } = useContext(DraftContext);
 
   const setForm = (id?: string) => {
@@ -25,13 +21,9 @@ export const PersistFormValues: React.FC<Props> = ({ id }) => {
     setForm(values.draftId);
   }, []);
 
-  useEffect(() => {
-    setForm(id);
-  }, [id]);
-
   // save the values to localStorage on update
   useEffect(() => {
-    if (values.draftId) {
+    if (values.draftId && dirty) {
       localStorage.setItem(values.draftId, JSON.stringify(values));
     }
     setDrafts();

--- a/src/user/views/adsManager/views/advanced/components/form/NewCampaign.tsx
+++ b/src/user/views/adsManager/views/advanced/components/form/NewCampaign.tsx
@@ -74,7 +74,7 @@ export function NewCampaign() {
       >
         <>
           <BaseForm isEdit={false} draftId={params.draftId} />
-          <PersistFormValues id={params.draftId} />
+          <PersistFormValues />
         </>
       </Formik>
     </Container>


### PR DESCRIPTION
Unable to reliantly reproduce on staging, but consistently reproduce locally: refreshing wipes local storage. Was able to reproduce in quick succession refreshing on staging.

This seems to reliably keep the form in localstorage