### PR TITLE
chore: reformat based on prettier v3 upgrade

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/src/auth/index.tsx
+++ b/src/auth/index.tsx
@@ -16,7 +16,7 @@ export const IAuthProvider: React.FC<IAuthProviderProps> = ({
   const [loading, setLoading] = useState(false);
 
   const getActiveAdvertiser = (
-    advertisers: IAdvertiser[]
+    advertisers: IAdvertiser[],
   ): IAdvertiser | undefined => {
     const advertiserId = window.localStorage.getItem("activeAdvertiser");
     if (advertisers.length === 0) {

--- a/src/auth/lib/index.ts
+++ b/src/auth/lib/index.ts
@@ -43,7 +43,7 @@ export const getCredentials = async (user: {
 
   if (!res.ok) {
     throw new Error(
-      "Unexpected error validating your credentials. Please try again later."
+      "Unexpected error validating your credentials. Please try again later.",
     );
   }
 
@@ -77,7 +77,7 @@ export async function submitRegistration(form: RegistrationForm) {
 
   if (!res.ok) {
     throw new Error(
-      "Unable to register your organization at this time. Please try again later."
+      "Unable to register your organization at this time. Please try again later.",
     );
   }
 }
@@ -118,7 +118,7 @@ export const getLink = async (user: { email: string }): Promise<void> => {
       method: "GET",
       mode: "cors",
       credentials: "include",
-    }
+    },
   );
 };
 
@@ -132,7 +132,7 @@ export const authorize = async (req: {
       method: "GET",
       mode: "cors",
       credentials: "include",
-    }
+    },
   );
 
   if (!res.ok) {

--- a/src/checkout/lib/index.ts
+++ b/src/checkout/lib/index.ts
@@ -2,7 +2,7 @@ import { buildAdServerEndpoint } from "util/environment";
 
 export async function createPaymentSession(
   advertiserId: string,
-  campaignId: string
+  campaignId: string,
 ): Promise<string> {
   const res = await fetch(buildAdServerEndpoint("/ads/checkout-session"), {
     method: "POST",
@@ -28,7 +28,7 @@ export async function createPaymentSession(
 
 export async function fetchPaymentSession(
   campaignId: string,
-  sessionId: string | null
+  sessionId: string | null,
 ): Promise<void> {
   let baseUrl = `/ads/checkout-session?referenceId=${campaignId}`;
   if (sessionId) {

--- a/src/components/Box/BoxContainer.tsx
+++ b/src/components/Box/BoxContainer.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren } from "react";
 import { Box, Container, Typography } from "@mui/material";
 
 export function BoxContainer(
-  props: { header?: React.ReactNode } & PropsWithChildren
+  props: { header?: React.ReactNode } & PropsWithChildren,
 ) {
   return (
     <Box mr={2}>

--- a/src/components/Campaigns/CampaignAgeFilter.tsx
+++ b/src/components/Campaigns/CampaignAgeFilter.tsx
@@ -16,7 +16,7 @@ export const CampaignAgeFilter: React.FC<Props> = ({
 }) => {
   const onOldCampaignToggle = (showOld: boolean) => {
     onChange(
-      showOld ? null : moment().subtract(6, "month").startOf("day").toDate()
+      showOld ? null : moment().subtract(6, "month").startOf("day").toDate(),
     );
   };
 

--- a/src/components/Card/CardContainer.tsx
+++ b/src/components/Card/CardContainer.tsx
@@ -5,7 +5,7 @@ export function CardContainer(
   props: {
     header?: string;
     additionalAction?: React.ReactNode;
-  } & PropsWithChildren
+  } & PropsWithChildren,
 ) {
   return (
     <Box mb={1} mt={2}>

--- a/src/components/Conversion/ConversionDisplay.tsx
+++ b/src/components/Conversion/ConversionDisplay.tsx
@@ -18,7 +18,7 @@ export function ConversionDisplay({ conversions, convErrors }: Props) {
 
   function extractConversionError(
     idx: number,
-    field: keyof Conversion
+    field: keyof Conversion,
   ): string | undefined {
     const errorObj = convErrors?.[idx];
 

--- a/src/components/EnhancedTable/EnhancedTable.tsx
+++ b/src/components/EnhancedTable/EnhancedTable.tsx
@@ -78,7 +78,7 @@ export interface ColumnAccessor<T>
 }
 
 function mkColumnAccessor<T>(
-  descriptor: ColumnDescriptor<T>
+  descriptor: ColumnDescriptor<T>,
 ): ColumnAccessor<T> {
   const {
     title,
@@ -140,13 +140,13 @@ const LoadingSkeleton: React.FC<{ cols: number; rows: number }> = ({
 
 export function EnhancedTable<T>(props: EnhancedTableProps<T>) {
   const [order, setOrder] = useState<SortDirection>(
-    props.initialSortDirection ?? "asc"
+    props.initialSortDirection ?? "asc",
   );
   const [orderBy, setOrderBy] = useState<number>(props.initialSortColumn ?? 0);
   const [filter, setFilter] = useState<string>("");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState<number>(
-    props.initialRowsPerPage ?? 25
+    props.initialRowsPerPage ?? 25,
   );
 
   const { rows } = props;
@@ -168,7 +168,7 @@ export function EnhancedTable<T>(props: EnhancedTableProps<T>) {
   };
 
   const handleChangeRowsPerPage = (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
@@ -196,7 +196,7 @@ export function EnhancedTable<T>(props: EnhancedTableProps<T>) {
       ? filteredRows
       : filteredRows.slice(
           page * rowsPerPage,
-          page * rowsPerPage + rowsPerPage
+          page * rowsPerPage + rowsPerPage,
         );
 
   return (

--- a/src/components/EnhancedTable/FilterInput.tsx
+++ b/src/components/EnhancedTable/FilterInput.tsx
@@ -17,7 +17,7 @@ export const FilterInput: React.FC<Props> = (props) => {
   // HT: https://dmitripavlutin.com/react-throttle-debounce/
   const debouncedChangeHandler = useMemo(
     () => _.debounce(props.setFilter, 300),
-    [props.setFilter]
+    [props.setFilter],
   );
 
   const onChangeHandler = (value: string) => {

--- a/src/components/EnhancedTable/renderers.tsx
+++ b/src/components/EnhancedTable/renderers.tsx
@@ -83,7 +83,7 @@ export const StandardRenderers: Record<string, CellValueRenderer> = {
 
 export function renderMonetaryAmount(
   value: number,
-  currency: string
+  currency: string,
 ): ReactNode {
   if (currency === "USD") {
     return `$${value.toLocaleString("en", {
@@ -96,7 +96,7 @@ export function renderMonetaryAmount(
 }
 
 export function campaignOnOffState(
-  c: CampaignSummaryFragment & { fromDate: Date | null; advertiserId: string }
+  c: CampaignSummaryFragment & { fromDate: Date | null; advertiserId: string },
 ): ReactNode {
   const [updateCampaign, { loading }] = useUpdateCampaignMutation({
     refetchQueries: [

--- a/src/components/Navigation/DraftMenu.tsx
+++ b/src/components/Navigation/DraftMenu.tsx
@@ -49,7 +49,7 @@ export function DraftMenu() {
             key={`draft-${d.draftId}-${idx}`}
             onClick={() => {
               history.push(
-                `/user/main/adsmanager/advanced/new/${d.draftId}/settings`
+                `/user/main/adsmanager/advanced/new/${d.draftId}/settings`,
               );
               setAnchorEl(null);
             }}

--- a/src/components/Segment/SegmentPicker.tsx
+++ b/src/components/Segment/SegmentPicker.tsx
@@ -17,13 +17,13 @@ interface Props {
 export const SegmentPicker: React.FC<Props> = ({ idx }: Props) => {
   const { data } = useSegmentsQuery();
   const activeSegments = _.sortBy(data?.segments?.data ?? [], (s) =>
-    s.name.toLowerCase()
+    s.name.toLowerCase(),
   );
 
   const [, targetMeta] = useField<boolean>(`adSets.${idx}.isNotTargeting`);
 
   const [, meta, helper] = useField<SegmentFragment[]>(
-    `adSets.${idx}.segments`
+    `adSets.${idx}.segments`,
   );
 
   useEffect(() => {

--- a/src/components/Steps/StepDrawer.tsx
+++ b/src/components/Steps/StepDrawer.tsx
@@ -37,7 +37,7 @@ export function StepDrawer({
   const history = useHistory();
   const activeStep = useRef<number>(0);
   activeStep.current = steps.findIndex((s) =>
-    history.location.pathname.includes(s.path)
+    history.location.pathname.includes(s.path),
   );
 
   return (

--- a/src/components/TimeZonePicker/useTimeZoneList.ts
+++ b/src/components/TimeZonePicker/useTimeZoneList.ts
@@ -117,6 +117,6 @@ export function useTimeZoneList(): TimeZoneInfo[] {
         })
         .orderBy("offsetMs")
         .valueOf(),
-    [usersTimeZone]
+    [usersTimeZone],
   );
 }

--- a/src/components/Url/UrlResolver.tsx
+++ b/src/components/Url/UrlResolver.tsx
@@ -25,11 +25,11 @@ interface ValidationDetail {
 }
 
 function extractViolations(
-  result: UrlValidationResult | undefined
+  result: UrlValidationResult | undefined,
 ): ValidationDetail[] {
   return _.uniqBy(
     (result?.response?.redirects ?? []).flatMap((r) => r.violations),
-    "summary"
+    "summary",
   );
 }
 

--- a/src/components/Url/use-url-validation.ts
+++ b/src/components/Url/use-url-validation.ts
@@ -35,7 +35,7 @@ export function useUrlValidation(url: string): UrlValidationResult {
 
   const debouncedSetUrlToCheck = useMemo(
     () => _.debounce(setUrlToCheck, 2000),
-    [setUrlToCheck]
+    [setUrlToCheck],
   );
 
   // cancel the debounce on onmount

--- a/src/form/DateFieldHelpers.tsx
+++ b/src/form/DateFieldHelpers.tsx
@@ -6,10 +6,10 @@ export const defaultStartDate = () =>
     addDays(
       zonedTimeToUtc(
         startOfDay(utcToZonedTime(twoDaysOut(), "America/New_York")),
-        "America/New_York"
+        "America/New_York",
       ),
-      1
-    )
+      1,
+    ),
   );
 
 export const defaultEndDate = () =>
@@ -17,10 +17,10 @@ export const defaultEndDate = () =>
     addDays(
       zonedTimeToUtc(
         endOfDay(utcToZonedTime(twoDaysOut(), "America/New_York")),
-        "America/New_York"
+        "America/New_York",
       ),
-      1
-    )
+      1,
+    ),
   );
 
 export const twoDaysOut = () => {

--- a/src/form/FormikHelpers.tsx
+++ b/src/form/FormikHelpers.tsx
@@ -105,7 +105,7 @@ interface FormikRadioControlProps {
 }
 
 export const FormikRadioControl: React.FC<FormikRadioControlProps> = (
-  props
+  props,
 ) => {
   return (
     <FormControl
@@ -166,7 +166,7 @@ export const FormikSubmitButton: React.FC<FormikSubmitButtonProps> = ({
     const unblock = history.block(
       !allowNavigation && formik.dirty
         ? "You’ve got unsaved changes. Are you sure you want to navigate away from this page?"
-        : true
+        : true,
     );
 
     return function cleanup() {

--- a/src/graphql/ad-set.generated.tsx
+++ b/src/graphql/ad-set.generated.tsx
@@ -294,12 +294,12 @@ export function useCreateAdSetMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateAdSetMutation,
     CreateAdSetMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<CreateAdSetMutation, CreateAdSetMutationVariables>(
     CreateAdSetDocument,
-    options
+    options,
   );
 }
 export type CreateAdSetMutationHookResult = ReturnType<
@@ -345,12 +345,12 @@ export function useUpdateAdSetMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateAdSetMutation,
     UpdateAdSetMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<UpdateAdSetMutation, UpdateAdSetMutationVariables>(
     UpdateAdSetDocument,
-    options
+    options,
   );
 }
 export type UpdateAdSetMutationHookResult = ReturnType<
@@ -396,12 +396,12 @@ export function useCreateAdMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateAdMutation,
     CreateAdMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<CreateAdMutation, CreateAdMutationVariables>(
     CreateAdDocument,
-    options
+    options,
   );
 }
 export type CreateAdMutationHookResult = ReturnType<typeof useCreateAdMutation>;
@@ -443,12 +443,12 @@ export function useUpdateAdMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateAdMutation,
     UpdateAdMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<UpdateAdMutation, UpdateAdMutationVariables>(
     UpdateAdDocument,
-    options
+    options,
   );
 }
 export type UpdateAdMutationHookResult = ReturnType<typeof useUpdateAdMutation>;

--- a/src/graphql/advertiser.generated.tsx
+++ b/src/graphql/advertiser.generated.tsx
@@ -215,24 +215,24 @@ export function useAdvertiserQuery(
   baseOptions: Apollo.QueryHookOptions<
     AdvertiserQuery,
     AdvertiserQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<AdvertiserQuery, AdvertiserQueryVariables>(
     AdvertiserDocument,
-    options
+    options,
   );
 }
 export function useAdvertiserLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     AdvertiserQuery,
     AdvertiserQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<AdvertiserQuery, AdvertiserQueryVariables>(
     AdvertiserDocument,
-    options
+    options,
   );
 }
 export type AdvertiserQueryHookResult = ReturnType<typeof useAdvertiserQuery>;
@@ -280,7 +280,7 @@ export function useUpdateAdvertiserMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateAdvertiserMutation,
     UpdateAdvertiserMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -327,7 +327,7 @@ export function useAdvertiserCampaignsQuery(
   baseOptions: Apollo.QueryHookOptions<
     AdvertiserCampaignsQuery,
     AdvertiserCampaignsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -339,7 +339,7 @@ export function useAdvertiserCampaignsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     AdvertiserCampaignsQuery,
     AdvertiserCampaignsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -358,7 +358,7 @@ export type AdvertiserCampaignsQueryResult = Apollo.QueryResult<
   AdvertiserCampaignsQueryVariables
 >;
 export function refetchAdvertiserCampaignsQuery(
-  variables: AdvertiserCampaignsQueryVariables
+  variables: AdvertiserCampaignsQueryVariables,
 ) {
   return { query: AdvertiserCampaignsDocument, variables: variables };
 }

--- a/src/graphql/analytics-overview.generated.tsx
+++ b/src/graphql/analytics-overview.generated.tsx
@@ -196,19 +196,19 @@ export function useAnalyticOverviewQuery(
   baseOptions: Apollo.QueryHookOptions<
     AnalyticOverviewQuery,
     AnalyticOverviewQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<AnalyticOverviewQuery, AnalyticOverviewQueryVariables>(
     AnalyticOverviewDocument,
-    options
+    options,
   );
 }
 export function useAnalyticOverviewLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     AnalyticOverviewQuery,
     AnalyticOverviewQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -227,7 +227,7 @@ export type AnalyticOverviewQueryResult = Apollo.QueryResult<
   AnalyticOverviewQueryVariables
 >;
 export function refetchAnalyticOverviewQuery(
-  variables: AnalyticOverviewQueryVariables
+  variables: AnalyticOverviewQueryVariables,
 ) {
   return { query: AnalyticOverviewDocument, variables: variables };
 }
@@ -265,7 +265,7 @@ export function useEngagementOverviewQuery(
   baseOptions: Apollo.QueryHookOptions<
     EngagementOverviewQuery,
     EngagementOverviewQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -277,7 +277,7 @@ export function useEngagementOverviewLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     EngagementOverviewQuery,
     EngagementOverviewQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -296,7 +296,7 @@ export type EngagementOverviewQueryResult = Apollo.QueryResult<
   EngagementOverviewQueryVariables
 >;
 export function refetchEngagementOverviewQuery(
-  variables: EngagementOverviewQueryVariables
+  variables: EngagementOverviewQueryVariables,
 ) {
   return { query: EngagementOverviewDocument, variables: variables };
 }

--- a/src/graphql/campaign.generated.tsx
+++ b/src/graphql/campaign.generated.tsx
@@ -452,24 +452,24 @@ export function useLoadCampaignQuery(
   baseOptions: Apollo.QueryHookOptions<
     LoadCampaignQuery,
     LoadCampaignQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<LoadCampaignQuery, LoadCampaignQueryVariables>(
     LoadCampaignDocument,
-    options
+    options,
   );
 }
 export function useLoadCampaignLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     LoadCampaignQuery,
     LoadCampaignQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<LoadCampaignQuery, LoadCampaignQueryVariables>(
     LoadCampaignDocument,
-    options
+    options,
   );
 }
 export type LoadCampaignQueryHookResult = ReturnType<
@@ -483,7 +483,7 @@ export type LoadCampaignQueryResult = Apollo.QueryResult<
   LoadCampaignQueryVariables
 >;
 export function refetchLoadCampaignQuery(
-  variables: LoadCampaignQueryVariables
+  variables: LoadCampaignQueryVariables,
 ) {
   return { query: LoadCampaignDocument, variables: variables };
 }
@@ -516,19 +516,19 @@ export function useLoadCampaignAdsQuery(
   baseOptions: Apollo.QueryHookOptions<
     LoadCampaignAdsQuery,
     LoadCampaignAdsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<LoadCampaignAdsQuery, LoadCampaignAdsQueryVariables>(
     LoadCampaignAdsDocument,
-    options
+    options,
   );
 }
 export function useLoadCampaignAdsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     LoadCampaignAdsQuery,
     LoadCampaignAdsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -547,7 +547,7 @@ export type LoadCampaignAdsQueryResult = Apollo.QueryResult<
   LoadCampaignAdsQueryVariables
 >;
 export function refetchLoadCampaignAdsQuery(
-  variables: LoadCampaignAdsQueryVariables
+  variables: LoadCampaignAdsQueryVariables,
 ) {
   return { query: LoadCampaignAdsDocument, variables: variables };
 }
@@ -585,7 +585,7 @@ export function useCreateCampaignMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateCampaignMutation,
     CreateCampaignMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -637,7 +637,7 @@ export function useUpdateCampaignMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateCampaignMutation,
     UpdateCampaignMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<

--- a/src/graphql/common.generated.tsx
+++ b/src/graphql/common.generated.tsx
@@ -83,24 +83,24 @@ export function useActiveGeocodesQuery(
   baseOptions?: Apollo.QueryHookOptions<
     ActiveGeocodesQuery,
     ActiveGeocodesQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<ActiveGeocodesQuery, ActiveGeocodesQueryVariables>(
     ActiveGeocodesDocument,
-    options
+    options,
   );
 }
 export function useActiveGeocodesLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     ActiveGeocodesQuery,
     ActiveGeocodesQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<ActiveGeocodesQuery, ActiveGeocodesQueryVariables>(
     ActiveGeocodesDocument,
-    options
+    options,
   );
 }
 export type ActiveGeocodesQueryHookResult = ReturnType<
@@ -114,7 +114,7 @@ export type ActiveGeocodesQueryResult = Apollo.QueryResult<
   ActiveGeocodesQueryVariables
 >;
 export function refetchActiveGeocodesQuery(
-  variables?: ActiveGeocodesQueryVariables
+  variables?: ActiveGeocodesQueryVariables,
 ) {
   return { query: ActiveGeocodesDocument, variables: variables };
 }
@@ -145,24 +145,24 @@ export const SegmentsDocument = gql`
  * });
  */
 export function useSegmentsQuery(
-  baseOptions?: Apollo.QueryHookOptions<SegmentsQuery, SegmentsQueryVariables>
+  baseOptions?: Apollo.QueryHookOptions<SegmentsQuery, SegmentsQueryVariables>,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<SegmentsQuery, SegmentsQueryVariables>(
     SegmentsDocument,
-    options
+    options,
   );
 }
 export function useSegmentsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     SegmentsQuery,
     SegmentsQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<SegmentsQuery, SegmentsQueryVariables>(
     SegmentsDocument,
-    options
+    options,
   );
 }
 export type SegmentsQueryHookResult = ReturnType<typeof useSegmentsQuery>;

--- a/src/graphql/creative.generated.tsx
+++ b/src/graphql/creative.generated.tsx
@@ -122,7 +122,7 @@ export function useAdvertiserCreativesQuery(
   baseOptions: Apollo.QueryHookOptions<
     AdvertiserCreativesQuery,
     AdvertiserCreativesQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -134,7 +134,7 @@ export function useAdvertiserCreativesLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     AdvertiserCreativesQuery,
     AdvertiserCreativesQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -153,7 +153,7 @@ export type AdvertiserCreativesQueryResult = Apollo.QueryResult<
   AdvertiserCreativesQueryVariables
 >;
 export function refetchAdvertiserCreativesQuery(
-  variables: AdvertiserCreativesQueryVariables
+  variables: AdvertiserCreativesQueryVariables,
 ) {
   return { query: AdvertiserCreativesDocument, variables: variables };
 }
@@ -197,7 +197,7 @@ export function useCreateNotificationCreativeMutation(
   baseOptions?: Apollo.MutationHookOptions<
     CreateNotificationCreativeMutation,
     CreateNotificationCreativeMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<
@@ -250,7 +250,7 @@ export function useUpdateNotificationCreativeMutation(
   baseOptions?: Apollo.MutationHookOptions<
     UpdateNotificationCreativeMutation,
     UpdateNotificationCreativeMutationVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useMutation<

--- a/src/graphql/url.generated.tsx
+++ b/src/graphql/url.generated.tsx
@@ -59,7 +59,7 @@ export function useValidateTargetUrlQuery(
   baseOptions: Apollo.QueryHookOptions<
     ValidateTargetUrlQuery,
     ValidateTargetUrlQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
@@ -71,7 +71,7 @@ export function useValidateTargetUrlLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
     ValidateTargetUrlQuery,
     ValidateTargetUrlQueryVariables
-  >
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
@@ -90,7 +90,7 @@ export type ValidateTargetUrlQueryResult = Apollo.QueryResult<
   ValidateTargetUrlQueryVariables
 >;
 export function refetchValidateTargetUrlQuery(
-  variables: ValidateTargetUrlQueryVariables
+  variables: ValidateTargetUrlQueryVariables,
 ) {
   return { query: ValidateTargetUrlDocument, variables: variables };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,5 +19,5 @@ root.render(
         <App />
       </BrowserRouter>
     </IAuthProvider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/user/ads/NotificationAd.tsx
+++ b/src/user/ads/NotificationAd.tsx
@@ -84,7 +84,7 @@ export function NotificationAd({ onCreate }: Props) {
             const input = creativeInput(
               advertiser.id,
               meta.value,
-              userId
+              userId,
             ) as CreateNotificationCreativeInput;
             create({ variables: { input } });
           }}

--- a/src/user/analytics/analyticsOverview/components/MetricFilter.tsx
+++ b/src/user/analytics/analyticsOverview/components/MetricFilter.tsx
@@ -12,7 +12,7 @@ type FilterMetric = {
 type SetMetricFunc = (
   key: keyof Metrics,
   value: keyof StatsMetric,
-  active: boolean
+  active: boolean,
 ) => void;
 
 type BoxProps = {

--- a/src/user/analytics/analyticsOverview/components/ReportUtils.tsx
+++ b/src/user/analytics/analyticsOverview/components/ReportUtils.tsx
@@ -59,7 +59,7 @@ export default function ReportUtils({
               campaign.name,
               userId ?? "",
               false,
-              setDownloadingCSV
+              setDownloadingCSV,
             )
           }
         >

--- a/src/user/analytics/analyticsOverview/lib/ads.library.ts
+++ b/src/user/analytics/analyticsOverview/lib/ads.library.ts
@@ -5,7 +5,7 @@ import { processStats } from "user/analytics/analyticsOverview/lib/overview.libr
 
 export function adEngagements(
   engagements: EngagementFragment[],
-  type: "creativeinstance" | "creativeset"
+  type: "creativeinstance" | "creativeset",
 ) {
   const grouped = _.groupBy(engagements, `${type}id`);
   const metrics = new Map<string, StatsMetric>();

--- a/src/user/analytics/analyticsOverview/lib/creative.library.ts
+++ b/src/user/analytics/analyticsOverview/lib/creative.library.ts
@@ -6,7 +6,7 @@ import { processStats } from "./overview.library";
 
 export function creativeEngagements(
   engagements: EngagementFragment[],
-  format: CampaignFormat
+  format: CampaignFormat,
 ) {
   const isNtp = format === CampaignFormat.NtpSi;
 

--- a/src/user/analytics/analyticsOverview/lib/csv.library.ts
+++ b/src/user/analytics/analyticsOverview/lib/csv.library.ts
@@ -6,7 +6,7 @@ export const downloadCSV = async (
   campaignName: string,
   userId: string,
   includeCountry: boolean,
-  setDownloadingCSV: Dispatch<boolean>
+  setDownloadingCSV: Dispatch<boolean>,
 ) => {
   setDownloadingCSV(true);
 
@@ -21,7 +21,7 @@ export const downloadCSV = async (
           "-x-user": userId,
           "Content-Type": "text/csv",
         },
-      }
+      },
     );
 
     const file = new Blob([response.data], {

--- a/src/user/analytics/analyticsOverview/lib/library.spec.ts
+++ b/src/user/analytics/analyticsOverview/lib/library.spec.ts
@@ -8,7 +8,9 @@ import { Metrics } from "../types";
 
 const price = 0.1;
 const pricetype = "view";
-const date = moment(new Date(2023, 1, 29, 8, 45)).utc(true).toDate();
+const date = moment(new Date(2023, 1, 29, 8, 45))
+  .utc(true)
+  .toDate();
 
 const commonFields = {
   creativeinstanceid: "",
@@ -204,17 +206,17 @@ it("should calculate landings, ctr, and cpa correctly", () => {
   const landed = calculateMetric(
     true,
     processed.landed.macos,
-    processed.click.macos
+    processed.click.macos,
   );
   const ctr = calculateMetric(
     true,
     processed.click.macos,
-    processed.view.macos
+    processed.view.macos,
   );
   const cpa = calculateMetric(
     false,
     processed.spend.macos,
-    processed.conversion.macos
+    processed.conversion.macos,
   );
 
   expect(landed).toBe(300);
@@ -226,7 +228,7 @@ it("should calculate landings, ctr, and cpa correctly", () => {
 it("should calculate metrics per creative id", () => {
   const creatives = creativeEngagements(
     engagements,
-    CampaignFormat.PushNotification
+    CampaignFormat.PushNotification,
   );
 
   expect(creatives).toMatchInlineSnapshot(`

--- a/src/user/analytics/analyticsOverview/lib/os.library.ts
+++ b/src/user/analytics/analyticsOverview/lib/os.library.ts
@@ -66,7 +66,7 @@ export function mapDevice(entries: [string, number][]) {
   };
 
   const byDesktop = entries.filter(
-    (c) => c[0] === "windows" || c[0] === "linux" || c[0] === "macos"
+    (c) => c[0] === "windows" || c[0] === "linux" || c[0] === "macos",
   );
   const byMobile = entries.filter((c) => c[0] === "ios" || c[0] === "android");
 

--- a/src/user/analytics/analyticsOverview/lib/overview.library.ts
+++ b/src/user/analytics/analyticsOverview/lib/overview.library.ts
@@ -78,7 +78,7 @@ export const baseOverviewChart: Options = {
 
 export const prepareChart = (
   metrics: Metrics,
-  processedData: MetricDataSet
+  processedData: MetricDataSet,
 ) => {
   const metricsEntries = Object.entries(metrics);
   return {
@@ -208,7 +208,7 @@ export const reduceMetric = (a: BaseMetric, b: BaseMetric) => {
 };
 
 export const processStats = (
-  engagements: EngagementFragment[]
+  engagements: EngagementFragment[],
 ): StatsMetric => {
   if (engagements.length === 0) {
     return {
@@ -245,7 +245,7 @@ export const processStats = (
 export function calculateMetric(
   isPercent: boolean,
   numerator: number,
-  denominator: number
+  denominator: number,
 ) {
   let metric: number;
   if (isPercent) {
@@ -260,7 +260,7 @@ export function calculateMetric(
 export const processData = (
   engagements: EngagementFragment[],
   metrics: Metrics,
-  grouping: string
+  grouping: string,
 ) => {
   // Group data by user setting
   const groupedData = _.groupBy(engagements, function (engagement) {

--- a/src/user/analytics/analyticsOverview/reports/campaign/EngagementsOverview.tsx
+++ b/src/user/analytics/analyticsOverview/reports/campaign/EngagementsOverview.tsx
@@ -83,7 +83,7 @@ export function EngagementsOverview({
   const setActiveMetric = (
     metric: keyof Metrics,
     value: keyof StatsMetric,
-    active: boolean
+    active: boolean,
   ) => {
     const metricsCopy = _.cloneDeep(metrics);
     const selectedMetric = metricsCopy[metric];

--- a/src/user/analytics/analyticsOverview/reports/os/components/OsBarChart.tsx
+++ b/src/user/analytics/analyticsOverview/reports/os/components/OsBarChart.tsx
@@ -8,7 +8,7 @@ export function OsBarChart(props: CalculatedOSMetric) {
   const [type, setType] = useState<keyof CalculatedOSMetric>("ctr");
 
   const mapToSeries = (
-    metric: keyof CalculatedOSMetric
+    metric: keyof CalculatedOSMetric,
   ): SeriesOptionsType[] => {
     let series: SeriesOptionsType = {
       name: "OS",

--- a/src/user/analytics/renderers/index.tsx
+++ b/src/user/analytics/renderers/index.tsx
@@ -29,7 +29,7 @@ export const renderEngagementCell = (
   loading: boolean,
   fragment: CampaignSummaryFragment,
   type: keyof EngagementOverview,
-  map?: Map<string, EngagementOverview>
+  map?: Map<string, EngagementOverview>,
 ) => {
   if (loading) {
     return <Skeleton />;
@@ -56,7 +56,7 @@ export const renderStatsCell = (
   loading: boolean,
   type: keyof StatsMetric,
   val?: StatsMetric,
-  currency?: string
+  currency?: string,
 ) => {
   if (loading) {
     return <Skeleton />;

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -44,7 +44,7 @@ const TYPE_CODE_LOOKUP: Record<string, string> = {
 
 export function transformNewForm(
   form: CampaignForm,
-  userId?: string
+  userId?: string,
 ): CreateCampaignInput {
   return {
     currency: form.currency,
@@ -92,7 +92,7 @@ function transformConversion(conv: Conversion[]) {
 
 function transformCreative(
   creative: Creative,
-  campaign: CampaignForm
+  campaign: CampaignForm,
 ): CreateAdInput {
   return {
     webhooks: [],
@@ -109,7 +109,7 @@ function transformCreative(
 export function creativeInput(
   advertiserId: string,
   creative: Creative,
-  userId?: string
+  userId?: string,
 ): CreateNotificationCreativeInput | UpdateNotificationCreativeInput {
   const baseNotification = {
     advertiserId,
@@ -140,7 +140,7 @@ export function creativeInput(
 
 export function editCampaignValues(
   campaign: CampaignFragment,
-  advertiserId: string
+  advertiserId: string,
 ): CampaignForm {
   const ads: AdFragment[] = _.flatMap(campaign.adSets, "ads");
 
@@ -200,13 +200,13 @@ function creativeList(ads?: AdFragment[] | null): Creative[] {
           state: c.state,
         };
       }),
-    "id"
+    "id",
   );
 }
 
 export function transformEditForm(
   form: CampaignForm,
-  id: string
+  id: string,
 ): UpdateCampaignInput {
   return {
     budget: form.budget,

--- a/src/user/settings/Settings.tsx
+++ b/src/user/settings/Settings.tsx
@@ -91,10 +91,10 @@ const Settings = () => {
   const openNewKeypairModal = () => {
     const keypair = tweetnacl.box.keyPair();
     const publicKey = btoa(
-      String.fromCharCode.apply(null, keypair.publicKey as unknown as number[])
+      String.fromCharCode.apply(null, keypair.publicKey as unknown as number[]),
     );
     const privateKey = btoa(
-      String.fromCharCode.apply(null, keypair.secretKey as unknown as number[])
+      String.fromCharCode.apply(null, keypair.secretKey as unknown as number[]),
     );
     setNewPublicKey(publicKey);
     setPrivateKey(privateKey);

--- a/src/user/views/adsManager/views/advanced/components/campaign/fields/BudgetField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/fields/BudgetField.tsx
@@ -19,7 +19,7 @@ export function BudgetField({ isEdit }: Props) {
   const { values, setFieldValue, errors } = useFormikContext<CampaignForm>();
   const [minBudget, setMinBudget] = useState(MIN_PER_CAMPAIGN);
   const campaignRuntime = Math.floor(
-    differenceInHours(new Date(values.endAt), new Date(values.startAt)) / 24
+    differenceInHours(new Date(values.endAt), new Date(values.startAt)) / 24,
   );
 
   useEffect(() => {

--- a/src/user/views/adsManager/views/advanced/components/form/EditCampaign.tsx
+++ b/src/user/views/adsManager/views/advanced/components/form/EditCampaign.tsx
@@ -42,7 +42,7 @@ export function EditCampaign() {
         campaign?.paymentType !== PaymentType.Stripe
       ) {
         history.push(
-          `/user/main/complete/edit?referenceId=${data.updateCampaign.id}`
+          `/user/main/complete/edit?referenceId=${data.updateCampaign.id}`,
         );
       } else {
         createPaymentSession(data.updateCampaign.id);

--- a/src/user/views/user/AdDetailTable.tsx
+++ b/src/user/views/user/AdDetailTable.tsx
@@ -36,7 +36,7 @@ export function AdDetailTable<T extends { id: string }>({
             loading,
             "spend",
             engagements.get(r.id),
-            campaign?.currency
+            campaign?.currency,
           ),
         align: "right",
       },
@@ -67,7 +67,7 @@ export function AdDetailTable<T extends { id: string }>({
         extendedRenderer: (r) =>
           renderStatsCell(loading, "ctr", engagements.get(r.id)),
         align: "right",
-      }
+      },
     );
   }
 

--- a/src/user/views/user/CampaignDetails.tsx
+++ b/src/user/views/user/CampaignDetails.tsx
@@ -27,7 +27,7 @@ export function CampaignDetails({ engagements, engagementLoading }: Props) {
   });
 
   const [tabValue, setTabValue] = useState(
-    Number(window.localStorage.getItem("tabValue") ?? 0)
+    Number(window.localStorage.getItem("tabValue") ?? 0),
   );
 
   const tabs = [

--- a/src/user/views/user/CampaignReportView.tsx
+++ b/src/user/views/user/CampaignReportView.tsx
@@ -50,7 +50,7 @@ export function CampaignReportView() {
   const filteredEngagements = (data?.campaign?.engagements ?? []).filter(
     (engagement) =>
       moment(engagement.createdat) >= moment.utc(startDate).startOf("day") &&
-      moment(engagement.createdat) <= moment.utc(endDate).endOf("day")
+      moment(engagement.createdat) <= moment.utc(endDate).endOf("day"),
   );
 
   const isLoading = loading || !data || !data.campaign || !startDate;

--- a/src/user/views/user/CampaignView.tsx
+++ b/src/user/views/user/CampaignView.tsx
@@ -9,7 +9,7 @@ import { CardContainer } from "components/Card/CardContainer";
 
 export function CampaignView() {
   const [fromDateFilter, setFromDateFilter] = useState<Date | null>(
-    moment().subtract(6, "month").startOf("day").toDate()
+    moment().subtract(6, "month").startOf("day").toDate(),
   );
 
   const { loading, data, error } = useAdvertiserCampaignsQuery({

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -5,7 +5,7 @@ export function buildAdServerEndpoint(suffix: string): string {
 export function buildAdServerV2Endpoint(suffix: string): string {
   return `${import.meta.env.REACT_APP_SERVER_ADDRESS.replace(
     "v1",
-    "v2"
+    "v2",
   )}${suffix}`;
 }
 

--- a/src/validation/CampaignSchema.test.ts
+++ b/src/validation/CampaignSchema.test.ts
@@ -31,8 +31,8 @@ it("should fail if the campaign start date is in past", () => {
   });
 
   expect(() =>
-    CampaignSchema.validateSync(c)
+    CampaignSchema.validateSync(c),
   ).toThrowErrorMatchingInlineSnapshot(
-    `"Start Date must be minimum of 2 days from today"`
+    `"Start Date must be minimum of 2 days from today"`,
   );
 });

--- a/src/validation/CampaignSchema.tsx
+++ b/src/validation/CampaignSchema.tsx
@@ -18,7 +18,7 @@ export const CampaignSchema = object().shape({
     .required()
     .min(
       MIN_PER_CAMPAIGN,
-      `Lifetime budget must be $${MIN_PER_CAMPAIGN} or more`
+      `Lifetime budget must be $${MIN_PER_CAMPAIGN} or more`,
     ),
   isCreating: boolean().default(false),
   newCreative: object().when("isCreating", {
@@ -45,7 +45,7 @@ export const CampaignSchema = object().shape({
           .matches(HttpsRegex, `URL must start with https://`)
           .matches(
             SimpleUrlRegexp,
-            `Please enter a valid Ad URL, for example https://brave.com`
+            `Please enter a valid Ad URL, for example https://brave.com`,
           ),
       }),
   }),
@@ -63,7 +63,7 @@ export const CampaignSchema = object().shape({
         schema
           .min(
             startOfDay(twoDaysOut()),
-            "Start Date must be minimum of 2 days from today"
+            "Start Date must be minimum of 2 days from today",
           )
           .required(),
     }),
@@ -77,7 +77,7 @@ export const CampaignSchema = object().shape({
       object().shape({
         code: string().required(),
         name: string().required(),
-      })
+      }),
     )
     .min(1, "At least one country must be targeted")
     .default([]),
@@ -108,7 +108,7 @@ export const CampaignSchema = object().shape({
             object().shape({
               code: string().required(),
               name: string().required(),
-            })
+            }),
           )
           .min(1, "At least one audience must be targeted")
           .default([]),
@@ -118,7 +118,7 @@ export const CampaignSchema = object().shape({
             object().shape({
               code: string().required(),
               name: string().required(),
-            })
+            }),
           )
           .min(1, "At least one platform must be targeted")
           .default([]),
@@ -132,23 +132,23 @@ export const CampaignSchema = object().shape({
                 .required("Conversion URL required.")
                 .matches(
                   TrailingAsteriskRegex,
-                  "Conversion URL must end in trailing asterisk (*)"
+                  "Conversion URL must end in trailing asterisk (*)",
                 ),
               observationWindow: number()
                 .oneOf(
                   [1, 7, 30],
-                  "Observation Window must be 1, 7, or 30 days."
+                  "Observation Window must be 1, 7, or 30 days.",
                 )
                 .required("Observation Window required."),
               type: string()
                 .oneOf(
                   ["postclick", "postview"],
-                  "Conversion type must be Post Click or Post View"
+                  "Conversion type must be Post Click or Post View",
                 )
                 .required("Conversion Type required."),
-            })
+            }),
           ),
         creatives: array().min(1, "Ad Sets must have at least one Ad"),
-      })
+      }),
     ),
 });

--- a/src/validation/RegistrationSchema.tsx
+++ b/src/validation/RegistrationSchema.tsx
@@ -23,14 +23,14 @@ export const RegistrationSchema = object().shape({
       .matches(HttpsRegex, `URL must start with https://`)
       .matches(
         SimpleUrlRegexp,
-        `Please enter a valid URL, for example https://brave.com`
+        `Please enter a valid URL, for example https://brave.com`,
       ),
     phone: string()
       .label("Organization phone number")
       .required()
       .matches(
         PhoneRegex,
-        "Please enter a valid phone number, including country code."
+        "Please enter a valid phone number, including country code.",
       ),
   }),
   address: object().shape({


### PR DESCRIPTION
Not all files were reformated previously, and doing this in one go avoids needless diffs later on.

Only change here is to run `npm run format`