### PR TITLE
fix: check campaign is active for label

### DIFF
--- a/src/components/Campaigns/Status.tsx
+++ b/src/components/Campaigns/Status.tsx
@@ -14,7 +14,7 @@ export const Status: React.FC<{
   let label = _.startCase(state);
 
   if (start) {
-    if (isBeforeStartDate(start)) {
+    if (isBeforeStartDate(start) && state === "active") {
       label = "Scheduled";
       color = "#e2e2fc";
     }


### PR DESCRIPTION
Should check campaign is active, before showing a status of "scheduled"