### PR TITLE
feat: add user profile & refactor to sidebar

### DIFF
--- a/src/auth/context/auth.interface.ts
+++ b/src/auth/context/auth.interface.ts
@@ -17,6 +17,7 @@ export interface IAuthState {
   isInitialized: boolean;
   isAuthenticated: boolean;
   setSessionUser: (u?: ResponseUser) => void;
+  fullName?: string;
   email?: string;
   role?: string;
   userId?: string;

--- a/src/auth/hooks/queries/useUser.ts
+++ b/src/auth/hooks/queries/useUser.ts
@@ -1,11 +1,17 @@
 import { useAuthContext } from "auth/context/auth.hook";
 
-type User = { userId?: string; role?: string; email?: string };
+type User = {
+  userId?: string;
+  role?: string;
+  email?: string;
+  fullName?: string;
+};
 
 export function useUser(): User {
-  const { userId, role, email } = useAuthContext();
+  const { userId, role, email, fullName } = useAuthContext();
 
   return {
+    fullName,
     userId,
     role,
     email,

--- a/src/auth/index.tsx
+++ b/src/auth/index.tsx
@@ -42,6 +42,7 @@ export const IAuthProvider: React.FC<IAuthProviderProps> = ({
         email: u.email,
         role: u.role,
         userId: u.id,
+        fullName: u.fullName,
         advertisers: u.advertisers,
         isAuthenticated: u.advertisers.length > 0 && !!active,
       }));

--- a/src/auth/registration/Register.tsx
+++ b/src/auth/registration/Register.tsx
@@ -33,42 +33,40 @@ export function Register() {
 
   return (
     <Background>
-      <Box>
-        <LandingPageAppBar />
-        <Toolbar sx={{ mb: 1.5 }} />
-        <Box display="flex" width="725px" flexDirection="column" mb={3}>
-          <Typography textAlign="center" variant="h4" sx={{ mb: 3 }}>
-            {steps[activeStep].label}
-          </Typography>
-          <Formik
-            initialValues={initialValues}
-            onSubmit={async (v: RegistrationForm, { setSubmitting }) => {
-              setSubmitting(true);
-              register(v);
-              setSubmitting(false);
-            }}
-            validationSchema={RegistrationSchema}
-          >
-            <Form>
-              <PaddedCardContainer>
-                {steps[activeStep].component}
-              </PaddedCardContainer>
+      <LandingPageAppBar />
+      <Toolbar sx={{ mb: 1.5 }} />
+      <Box display="flex" width="725px" flexDirection="column" mb={3}>
+        <Typography textAlign="center" variant="h4" sx={{ mb: 3 }}>
+          {steps[activeStep].label}
+        </Typography>
+        <Formik
+          initialValues={initialValues}
+          onSubmit={async (v: RegistrationForm, { setSubmitting }) => {
+            setSubmitting(true);
+            register(v);
+            setSubmitting(false);
+          }}
+          validationSchema={RegistrationSchema}
+        >
+          <Form>
+            <PaddedCardContainer>
+              {steps[activeStep].component}
+            </PaddedCardContainer>
 
-              <NextAndBack
-                activeStep={activeStep}
-                steps={steps.length - 1}
-                onNext={() => setActiveStep(activeStep + 1)}
-                onBack={() => setActiveStep(activeStep - 1)}
-                final={
-                  <FormikSubmitButton
-                    isCreate={true}
-                    label="Submit for approval"
-                  />
-                }
-              />
-            </Form>
-          </Formik>
-        </Box>
+            <NextAndBack
+              activeStep={activeStep}
+              steps={steps.length - 1}
+              onNext={() => setActiveStep(activeStep + 1)}
+              onBack={() => setActiveStep(activeStep - 1)}
+              final={
+                <FormikSubmitButton
+                  isCreate={true}
+                  label="Submit for approval"
+                />
+              }
+            />
+          </Form>
+        </Formik>
       </Box>
     </Background>
   );

--- a/src/auth/views/LandingPage.tsx
+++ b/src/auth/views/LandingPage.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Box, Button, Stack, Typography } from "@mui/material";
 import goals from "../../../images.svg";
 import { useIsAuthenticated } from "auth/hooks/queries/useIsAuthenticated";
+import { Link as RouterLink } from "react-router-dom";
 
 const GradientText = {
   backgroundImage:
@@ -40,13 +41,14 @@ export function LandingPage() {
           <Box>
             <Button
               variant="contained"
+              component={RouterLink}
               sx={{
                 width: "Hug (165px)",
                 height: "Fixed (60px)",
                 padding: "18px 24px 18px 24px",
               }}
               size="large"
-              href={isAuthenticated ? "/user/main" : "/register"}
+              to={isAuthenticated ? "/user/main" : "/register"}
             >
               {isAuthenticated ? "Dashboard" : "Get Started"}
             </Button>

--- a/src/auth/views/Login.tsx
+++ b/src/auth/views/Login.tsx
@@ -45,7 +45,7 @@ export function Login() {
         color="primary"
         size="large"
         variant="contained"
-        sx={{ mt: 2, textTransform: "none", mb: 1 }}
+        sx={{ mt: 2, mb: 1 }}
         disabled={loading}
         loading={loading}
         onClick={() => {

--- a/src/auth/views/MagicLink.tsx
+++ b/src/auth/views/MagicLink.tsx
@@ -66,7 +66,7 @@ export function MagicLink() {
         color="primary"
         size="large"
         variant="contained"
-        sx={{ mt: 2, textTransform: "none", mb: 1 }}
+        sx={{ mt: 2, mb: 1 }}
         disabled={loading}
         loading={loading}
         onClick={() => {

--- a/src/components/AppBar/LandingPageAppBar.tsx
+++ b/src/components/AppBar/LandingPageAppBar.tsx
@@ -10,6 +10,7 @@ import {
   LinkProps,
   Stack,
   Toolbar,
+  Typography,
 } from "@mui/material";
 import ads from "../../../branding.svg";
 import { Link as RouterLink, useRouteMatch } from "react-router-dom";
@@ -23,7 +24,11 @@ export function LandingPageAppBar() {
   const links = [
     {
       component: isAuthenticated ? null : (
-        <HelpLink label="Get Started" props={{ href: "/register" }} />
+        <RouterLink to={"/register"} style={{ textDecoration: "none" }}>
+          <Typography variant="subtitle1" color="text.primary">
+            Get started
+          </Typography>
+        </RouterLink>
       ),
     },
     {
@@ -97,7 +102,8 @@ function AuthedButton(props: { isAuthenticated?: boolean }) {
     <Button
       variant="outlined"
       size="large"
-      href={!props.isAuthenticated ? "/auth/link" : undefined}
+      component={RouterLink}
+      to={!props.isAuthenticated ? "/auth/link" : "/"}
       onClick={props.isAuthenticated ? () => signOut() : undefined}
     >
       {props.isAuthenticated ? "Sign out" : "Log in"}

--- a/src/components/AppBar/LandingPageAppBar.tsx
+++ b/src/components/AppBar/LandingPageAppBar.tsx
@@ -97,7 +97,6 @@ function AuthedButton(props: { isAuthenticated?: boolean }) {
     <Button
       variant="outlined"
       size="large"
-      sx={{ textTransform: "none" }}
       href={!props.isAuthenticated ? "/auth/link" : undefined}
       onClick={props.isAuthenticated ? () => signOut() : undefined}
     >

--- a/src/components/Card/CardContainer.tsx
+++ b/src/components/Card/CardContainer.tsx
@@ -1,14 +1,16 @@
 import React, { PropsWithChildren } from "react";
 import { Box, Card, CardContent, Stack, Typography } from "@mui/material";
+import { SxProps } from "@mui/system";
 
 export function CardContainer(
   props: {
     header?: string;
     additionalAction?: React.ReactNode;
+    sx?: SxProps;
   } & PropsWithChildren,
 ) {
   return (
-    <Box mb={1} mt={2}>
+    <Box mb={1} mt={2} sx={props.sx}>
       {(props.header || props.additionalAction) && (
         <Stack
           direction="row"

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -33,7 +33,7 @@ type RouteOption = {
   onClick?: (event: React.MouseEvent<any>) => void;
 };
 
-const drawerWidth = 140;
+const drawerWidth = 120;
 export default function MiniSideBar({ children }: PropsWithChildren) {
   const dashboardRoutes: RouteOption[] = [
     {

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -186,7 +186,7 @@ export function SupportMenu() {
       <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
         <MenuItem
           onClick={() => {
-            window.open("https://brave.com/brave-ads", "_blank");
+            window.open("https://brave.com/brave-ads", "_blank", "noopener");
             setAnchorEl(null);
           }}
         >
@@ -194,7 +194,7 @@ export function SupportMenu() {
         </MenuItem>
         <MenuItem
           onClick={() => {
-            window.open("mailto:selfserve@brave.com", "_self");
+            window.open("mailto:selfserve@brave.com", "_self", "noopener");
             setAnchorEl(null);
           }}
         >

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -3,13 +3,14 @@ import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
 import CssBaseline from "@mui/material/CssBaseline";
 import Divider from "@mui/material/Divider";
-import { Button, Drawer, Typography } from "@mui/material";
+import { Button, Drawer, Typography, SvgIcon } from "@mui/material";
 import { PropsWithChildren } from "react";
 import CampaignOutlinedIcon from "@mui/icons-material/CampaignOutlined";
 import AccountBalanceOutlinedIcon from "@mui/icons-material/AccountBalanceOutlined";
 import AccountBoxOutlinedIcon from "@mui/icons-material/AccountBoxOutlined";
 import HeadsetMicOutlinedIcon from "@mui/icons-material/HeadsetMicOutlined";
 import InsertPhotoOutlinedIcon from "@mui/icons-material/InsertPhotoOutlined";
+import LightbulbOutlinedIcon from "@mui/icons-material/LightbulbOutlined";
 
 type RouteOption = {
   label: string;
@@ -24,18 +25,45 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
     {
       label: "Campaigns",
       href: "/user/main/campaign",
-      icon: <CampaignOutlinedIcon fontSize="large" />,
+      icon: (
+        <CampaignOutlinedIcon
+          fontSize="large"
+          sx={{ color: "rgba(161, 171, 186, 1)" }}
+        />
+      ),
+    },
+    // Possible future enhancements, not visible to user but help keep spacing
+    {
+      label: "Creatives",
+      href: "/user/main/creatives",
+      icon: (
+        <LightbulbOutlinedIcon
+          fontSize="large"
+          sx={{ color: "rgba(161, 171, 186, 1)" }}
+        />
+      ),
+      disabled: true,
     },
     {
       label: "Assets",
       href: "/user/main/assets",
-      icon: <InsertPhotoOutlinedIcon fontSize="large" />,
+      icon: (
+        <InsertPhotoOutlinedIcon
+          fontSize="large"
+          sx={{ color: "rgba(161, 171, 186, 1)" }}
+        />
+      ),
       disabled: true,
     },
     {
       label: "Audiences",
       href: "/user/main/audiences",
-      icon: <CampaignOutlinedIcon fontSize="large" />,
+      icon: (
+        <CampaignOutlinedIcon
+          fontSize="large"
+          sx={{ color: "rgba(161, 171, 186, 1)" }}
+        />
+      ),
       disabled: true,
     },
   ];
@@ -44,17 +72,32 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
     {
       label: "Account",
       href: "/user/main/settings",
-      icon: <AccountBalanceOutlinedIcon fontSize="large" />,
+      icon: (
+        <AccountBalanceOutlinedIcon
+          fontSize="large"
+          sx={{ color: "rgba(161, 171, 186, 1)" }}
+        />
+      ),
     },
     {
       label: "Profile",
       href: "/user/main/profile",
-      icon: <AccountBoxOutlinedIcon fontSize="large" />,
+      icon: (
+        <AccountBoxOutlinedIcon
+          fontSize="large"
+          sx={{ color: "rgba(161, 171, 186, 1)" }}
+        />
+      ),
     },
     {
       label: "Support",
       href: "mailto:selfserve@brave.com",
-      icon: <HeadsetMicOutlinedIcon fontSize="large" />,
+      icon: (
+        <HeadsetMicOutlinedIcon
+          fontSize="large"
+          sx={{ color: "rgba(161, 171, 186, 1)" }}
+        />
+      ),
     },
   ];
 
@@ -101,7 +144,6 @@ const ItemBox = (props: RouteOption) => {
       href={props.href}
       disabled={props.disabled}
       sx={{
-        textTransform: "none",
         padding: "15px 6px 15px 6px",
         borderRadius: "0px",
         gap: "8px",
@@ -114,7 +156,7 @@ const ItemBox = (props: RouteOption) => {
         alignItems="center"
       >
         {props.icon}
-        <Typography>{props.label}</Typography>
+        <Typography color="rgba(63, 72, 85, 1)">{props.label}</Typography>
       </Box>
     </Box>
   );

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -1,25 +1,39 @@
 import * as React from "react";
 import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
-import CssBaseline from "@mui/material/CssBaseline";
 import Divider from "@mui/material/Divider";
-import { Button, Drawer, Typography, SvgIcon } from "@mui/material";
-import { PropsWithChildren } from "react";
+import {
+  Button,
+  Drawer,
+  Link,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Typography,
+} from "@mui/material";
+import { PropsWithChildren, useState } from "react";
+import { Link as RouterLink, useRouteMatch } from "react-router-dom";
 import CampaignOutlinedIcon from "@mui/icons-material/CampaignOutlined";
 import AccountBalanceOutlinedIcon from "@mui/icons-material/AccountBalanceOutlined";
 import AccountBoxOutlinedIcon from "@mui/icons-material/AccountBoxOutlined";
 import HeadsetMicOutlinedIcon from "@mui/icons-material/HeadsetMicOutlined";
 import InsertPhotoOutlinedIcon from "@mui/icons-material/InsertPhotoOutlined";
 import LightbulbOutlinedIcon from "@mui/icons-material/LightbulbOutlined";
+import PeopleOutlineOutlinedIcon from "@mui/icons-material/PeopleOutlineOutlined";
 
 type RouteOption = {
   label: string;
   href: string;
   icon: React.ReactNode;
   disabled?: boolean;
+  onClick?: (event: React.MouseEvent<any>) => void;
 };
 
-const drawerWidth = 120;
+const drawerWidth = 140;
 export default function MiniSideBar({ children }: PropsWithChildren) {
   const dashboardRoutes: RouteOption[] = [
     {
@@ -28,7 +42,7 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
       icon: (
         <CampaignOutlinedIcon
           fontSize="large"
-          sx={{ color: "rgba(161, 171, 186, 1)" }}
+          sx={{ color: "text.secondary" }}
         />
       ),
     },
@@ -39,7 +53,7 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
       icon: (
         <LightbulbOutlinedIcon
           fontSize="large"
-          sx={{ color: "rgba(161, 171, 186, 1)" }}
+          sx={{ color: "text.secondary" }}
         />
       ),
       disabled: true,
@@ -50,7 +64,7 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
       icon: (
         <InsertPhotoOutlinedIcon
           fontSize="large"
-          sx={{ color: "rgba(161, 171, 186, 1)" }}
+          sx={{ color: "text.secondary" }}
         />
       ),
       disabled: true,
@@ -59,9 +73,9 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
       label: "Audiences",
       href: "/user/main/audiences",
       icon: (
-        <CampaignOutlinedIcon
+        <PeopleOutlineOutlinedIcon
           fontSize="large"
-          sx={{ color: "rgba(161, 171, 186, 1)" }}
+          sx={{ color: "text.secondary" }}
         />
       ),
       disabled: true,
@@ -75,7 +89,7 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
       icon: (
         <AccountBalanceOutlinedIcon
           fontSize="large"
-          sx={{ color: "rgba(161, 171, 186, 1)" }}
+          sx={{ color: "text.secondary" }}
         />
       ),
     },
@@ -85,17 +99,7 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
       icon: (
         <AccountBoxOutlinedIcon
           fontSize="large"
-          sx={{ color: "rgba(161, 171, 186, 1)" }}
-        />
-      ),
-    },
-    {
-      label: "Support",
-      href: "mailto:selfserve@brave.com",
-      icon: (
-        <HeadsetMicOutlinedIcon
-          fontSize="large"
-          sx={{ color: "rgba(161, 171, 186, 1)" }}
+          sx={{ color: "text.secondary" }}
         />
       ),
     },
@@ -103,7 +107,6 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
 
   return (
     <Box sx={{ display: "flex" }}>
-      <CssBaseline />
       <Drawer
         variant="permanent"
         open
@@ -112,11 +115,7 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
         }}
       >
         <Toolbar />
-        <Box
-          sx={{
-            padding: "6px 0px 6px 0px",
-          }}
-        >
+        <List>
           {dashboardRoutes.map((dr) => (
             <ItemBox
               href={dr.href}
@@ -129,7 +128,8 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
           {settingsRoutes.map((sr) => (
             <ItemBox href={sr.href} icon={sr.icon} label={sr.label} />
           ))}
-        </Box>
+          <SupportMenu />
+        </List>
       </Drawer>
       {children}
     </Box>
@@ -137,27 +137,73 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
 }
 
 const ItemBox = (props: RouteOption) => {
+  const match = useRouteMatch();
   return (
-    <Box
-      display="flex"
-      component={Button}
-      href={props.href}
-      disabled={props.disabled}
+    <ListItemButton
+      component={RouterLink}
+      to={props.href}
       sx={{
-        padding: "15px 6px 15px 6px",
+        display: "flex",
+        flexDirection: "column",
         borderRadius: "0px",
-        gap: "8px",
+        gap: "3px",
+        visibility: props.disabled ? "hidden" : "visible",
+        paddingLeft: "5px",
+        paddingRight: "5px",
       }}
+      selected={match.url.includes(props.href)}
+      onClick={props.onClick}
     >
-      <Box
-        sx={{ visibility: props.disabled ? "hidden" : "visible" }}
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-      >
-        {props.icon}
-        <Typography color="rgba(63, 72, 85, 1)">{props.label}</Typography>
-      </Box>
-    </Box>
+      <ListItemIcon sx={{ minWidth: "unset" }}>{props.icon}</ListItemIcon>
+      <ListItemText disableTypography>
+        <Typography textAlign="center">{props.label}</Typography>
+      </ListItemText>
+    </ListItemButton>
   );
 };
+
+export function SupportMenu() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  return (
+    <>
+      <ItemBox
+        label="Support"
+        href="#"
+        icon={
+          <HeadsetMicOutlinedIcon
+            fontSize="large"
+            sx={{ color: "text.secondary" }}
+          />
+        }
+        onClick={handleClick}
+      />
+      <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
+        <MenuItem
+          onClick={() => {
+            window.open("https://brave.com/brave-ads", "_blank");
+            setAnchorEl(null);
+          }}
+        >
+          Advertiser Resources
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            window.open("mailto:selfserve@brave.com", "_self");
+            setAnchorEl(null);
+          }}
+        >
+          Email support:{" "}
+          <Link sx={{ ml: 1 }} underline="none">
+            selfserve@brave.com
+          </Link>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Toolbar from "@mui/material/Toolbar";
+import CssBaseline from "@mui/material/CssBaseline";
+import Divider from "@mui/material/Divider";
+import { Button, Drawer, Typography } from "@mui/material";
+import { PropsWithChildren } from "react";
+import CampaignOutlinedIcon from "@mui/icons-material/CampaignOutlined";
+import AccountBalanceOutlinedIcon from "@mui/icons-material/AccountBalanceOutlined";
+import AccountBoxOutlinedIcon from "@mui/icons-material/AccountBoxOutlined";
+import HeadsetMicOutlinedIcon from "@mui/icons-material/HeadsetMicOutlined";
+import InsertPhotoOutlinedIcon from "@mui/icons-material/InsertPhotoOutlined";
+
+type RouteOption = {
+  label: string;
+  href: string;
+  icon: React.ReactNode;
+  disabled?: boolean;
+};
+
+const drawerWidth = 120;
+export default function MiniSideBar({ children }: PropsWithChildren) {
+  const dashboardRoutes: RouteOption[] = [
+    {
+      label: "Campaigns",
+      href: "/user/main/campaign",
+      icon: <CampaignOutlinedIcon fontSize="large" />,
+    },
+    {
+      label: "Assets",
+      href: "/user/main/assets",
+      icon: <InsertPhotoOutlinedIcon fontSize="large" />,
+      disabled: true,
+    },
+    {
+      label: "Audiences",
+      href: "/user/main/audiences",
+      icon: <CampaignOutlinedIcon fontSize="large" />,
+      disabled: true,
+    },
+  ];
+
+  const settingsRoutes: RouteOption[] = [
+    {
+      label: "Account",
+      href: "/user/main/settings",
+      icon: <AccountBalanceOutlinedIcon fontSize="large" />,
+    },
+    {
+      label: "Profile",
+      href: "/user/main/profile",
+      icon: <AccountBoxOutlinedIcon fontSize="large" />,
+    },
+    {
+      label: "Support",
+      href: "mailto:selfserve@brave.com",
+      icon: <HeadsetMicOutlinedIcon fontSize="large" />,
+    },
+  ];
+
+  return (
+    <Box sx={{ display: "flex" }}>
+      <CssBaseline />
+      <Drawer
+        variant="permanent"
+        open
+        sx={{
+          width: drawerWidth,
+        }}
+      >
+        <Toolbar />
+        <Box
+          sx={{
+            padding: "6px 0px 6px 0px",
+          }}
+        >
+          {dashboardRoutes.map((dr) => (
+            <ItemBox
+              href={dr.href}
+              icon={dr.icon}
+              label={dr.label}
+              disabled={dr.disabled}
+            />
+          ))}
+          <Divider sx={{ mt: 3, mb: 3 }} />
+          {settingsRoutes.map((sr) => (
+            <ItemBox href={sr.href} icon={sr.icon} label={sr.label} />
+          ))}
+        </Box>
+      </Drawer>
+      {children}
+    </Box>
+  );
+}
+
+const ItemBox = (props: RouteOption) => {
+  return (
+    <Box
+      display="flex"
+      component={Button}
+      href={props.href}
+      disabled={props.disabled}
+      sx={{
+        textTransform: "none",
+        padding: "15px 6px 15px 6px",
+        borderRadius: "0px",
+        gap: "8px",
+      }}
+    >
+      <Box
+        sx={{ visibility: props.disabled ? "hidden" : "visible" }}
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+      >
+        {props.icon}
+        <Typography>{props.label}</Typography>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/Navigation/DraftMenu.tsx
+++ b/src/components/Navigation/DraftMenu.tsx
@@ -2,7 +2,14 @@ import * as React from "react";
 import { useContext, useState } from "react";
 
 import { useHistory } from "react-router-dom";
-import { Badge, IconButton, Menu, MenuItem, Tooltip } from "@mui/material";
+import {
+  Badge,
+  Button,
+  IconButton,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from "@mui/material";
 import DraftsIcon from "@mui/icons-material/Drafts";
 import { DraftContext } from "state/context";
 
@@ -18,15 +25,16 @@ export function DraftMenu() {
 
   return (
     <>
-      <Tooltip title="Local Campaign Drafts">
-        <span>
-          <IconButton disabled={drafts.length === 0} onClick={handleClick}>
-            <Badge color="primary" badgeContent={drafts.length}>
-              <DraftsIcon fontSize="medium" />
-            </Badge>
-          </IconButton>
-        </span>
-      </Tooltip>
+      <Button
+        disabled={drafts.length === 0}
+        onClick={handleClick}
+        sx={{ pr: 3 }}
+        endIcon={
+          <Badge color="primary" badgeContent={drafts.length} sx={{ ml: 1 }} />
+        }
+      >
+        Campaign Drafts
+      </Button>
       <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
         <MenuItem
           disabled

--- a/src/components/Navigation/DraftMenu.tsx
+++ b/src/components/Navigation/DraftMenu.tsx
@@ -18,7 +18,7 @@ export function DraftMenu() {
 
   return (
     <>
-      <Tooltip title="Drafts">
+      <Tooltip title="Local Campaign Drafts">
         <span>
           <IconButton disabled={drafts.length === 0} onClick={handleClick}>
             <Badge color="primary" badgeContent={drafts.length}>

--- a/src/components/Navigation/Navbar.tsx
+++ b/src/components/Navigation/Navbar.tsx
@@ -58,12 +58,7 @@ export function Navbar() {
             New Campaign
           </Button>
         )}
-        <Button
-          variant="outlined"
-          size="medium"
-          sx={{ textTransform: "none" }}
-          onClick={() => signOut()}
-        >
+        <Button variant="outlined" size="medium" onClick={() => signOut()}>
           Sign out
         </Button>
       </Toolbar>

--- a/src/components/Navigation/Navbar.tsx
+++ b/src/components/Navigation/Navbar.tsx
@@ -16,8 +16,10 @@ import { DraftMenu } from "components/Navigation/DraftMenu";
 import moment from "moment";
 import ads from "../../../branding.svg";
 import { useAdvertiser } from "auth/hooks/queries/useAdvertiser";
+import { useSignOut } from "auth/hooks/mutations/useSignOut";
 
 export function Navbar() {
+  const { signOut } = useSignOut();
   const { advertiser } = useAdvertiser();
   const history = useHistory();
   const { url } = useRouteMatch();
@@ -42,23 +44,7 @@ export function Navbar() {
         <Stack direction="row" alignItems="center" spacing={2}>
           <img src={ads} alt="Ads" height="31px" width="180px" />
           <Divider orientation="vertical" flexItem />
-          {advertiser.selfServiceCreate && (
-            <>
-              <DraftMenu />
-              <div>
-                <Typography color="black" variant="body2">
-                  Need Help?
-                  <Link
-                    sx={{ ml: 1 }}
-                    href="mailto:selfserve@brave.com"
-                    underline="none"
-                  >
-                    selfserve@brave.com
-                  </Link>
-                </Typography>
-              </div>
-            </>
-          )}
+          {advertiser.selfServiceCreate && <DraftMenu />}
         </Stack>
         <div style={{ flexGrow: 1 }} />
         {advertiser.selfServiceCreate && (
@@ -66,13 +52,20 @@ export function Navbar() {
             onClick={() => history.push(newUrl)}
             size="medium"
             variant="contained"
-            sx={{ mr: 5 }}
+            sx={{ mr: 3 }}
             disabled={isNewCampaignPage || isCompletePage || !advertiser.agreed}
           >
             New Campaign
           </Button>
         )}
-        <UserMenu />
+        <Button
+          variant="outlined"
+          size="medium"
+          sx={{ textTransform: "none" }}
+          onClick={() => signOut()}
+        >
+          Sign out
+        </Button>
       </Toolbar>
     </AppBar>
   );

--- a/src/components/Steps/ActionButtons.tsx
+++ b/src/components/Steps/ActionButtons.tsx
@@ -12,18 +12,14 @@ export function ActionButtons() {
 
   return (
     <Stack mt={3} spacing={2} mr={1}>
-      <Button
-        size="small"
-        sx={{ textTransform: "none" }}
-        onClick={() => history.push("/user/main")}
-      >
+      <Button size="small" onClick={() => history.push("/user/main")}>
         Return to dashboard
       </Button>
       {values.draftId !== undefined && (
         <Button
           size="small"
           color="error"
-          sx={{ textTransform: "none", mr: 1 }}
+          sx={{ mr: 1 }}
           onClick={() => {
             localStorage.removeItem(values.draftId!);
             setDrafts();

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -361,6 +361,10 @@ export type RejectCampaignInput = {
   option: CampaignRejection;
 };
 
+export enum RequestedDimensions {
+  Ad = "AD",
+}
+
 export type SearchHomepagePayloadInput = {
   body: Scalars["String"];
   ctaText?: Scalars["String"];

--- a/src/graphql/user.generated.tsx
+++ b/src/graphql/user.generated.tsx
@@ -1,12 +1,44 @@
 import * as Types from "./types";
 
 import { gql } from "@apollo/client";
+import * as Apollo from "@apollo/client";
+const defaultOptions = {} as const;
 export type UserFragment = {
   __typename?: "User";
   email: string;
   fullName: string;
   id: string;
   role: string;
+};
+
+export type LoadUserQueryVariables = Types.Exact<{
+  id: Types.Scalars["String"];
+}>;
+
+export type LoadUserQuery = {
+  __typename?: "Query";
+  user: {
+    __typename?: "User";
+    email: string;
+    fullName: string;
+    id: string;
+    role: string;
+  };
+};
+
+export type UpdateUserMutationVariables = Types.Exact<{
+  input: Types.UpdateUserInput;
+}>;
+
+export type UpdateUserMutation = {
+  __typename?: "Mutation";
+  updateUser: {
+    __typename?: "User";
+    email: string;
+    fullName: string;
+    id: string;
+    role: string;
+  };
 };
 
 export const UserFragmentDoc = gql`
@@ -17,3 +49,111 @@ export const UserFragmentDoc = gql`
     role
   }
 `;
+export const LoadUserDocument = gql`
+  query LoadUser($id: String!) {
+    user(id: $id) {
+      ...User
+    }
+  }
+  ${UserFragmentDoc}
+`;
+
+/**
+ * __useLoadUserQuery__
+ *
+ * To run a query within a React component, call `useLoadUserQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLoadUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLoadUserQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useLoadUserQuery(
+  baseOptions: Apollo.QueryHookOptions<LoadUserQuery, LoadUserQueryVariables>,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<LoadUserQuery, LoadUserQueryVariables>(
+    LoadUserDocument,
+    options,
+  );
+}
+export function useLoadUserLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    LoadUserQuery,
+    LoadUserQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<LoadUserQuery, LoadUserQueryVariables>(
+    LoadUserDocument,
+    options,
+  );
+}
+export type LoadUserQueryHookResult = ReturnType<typeof useLoadUserQuery>;
+export type LoadUserLazyQueryHookResult = ReturnType<
+  typeof useLoadUserLazyQuery
+>;
+export type LoadUserQueryResult = Apollo.QueryResult<
+  LoadUserQuery,
+  LoadUserQueryVariables
+>;
+export function refetchLoadUserQuery(variables: LoadUserQueryVariables) {
+  return { query: LoadUserDocument, variables: variables };
+}
+export const UpdateUserDocument = gql`
+  mutation UpdateUser($input: UpdateUserInput!) {
+    updateUser(updateUserInput: $input) {
+      ...User
+    }
+  }
+  ${UserFragmentDoc}
+`;
+export type UpdateUserMutationFn = Apollo.MutationFunction<
+  UpdateUserMutation,
+  UpdateUserMutationVariables
+>;
+
+/**
+ * __useUpdateUserMutation__
+ *
+ * To run a mutation, you first call `useUpdateUserMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateUserMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateUserMutation, { data, loading, error }] = useUpdateUserMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateUserMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateUserMutation,
+    UpdateUserMutationVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<UpdateUserMutation, UpdateUserMutationVariables>(
+    UpdateUserDocument,
+    options,
+  );
+}
+export type UpdateUserMutationHookResult = ReturnType<
+  typeof useUpdateUserMutation
+>;
+export type UpdateUserMutationResult =
+  Apollo.MutationResult<UpdateUserMutation>;
+export type UpdateUserMutationOptions = Apollo.BaseMutationOptions<
+  UpdateUserMutation,
+  UpdateUserMutationVariables
+>;

--- a/src/graphql/user.graphql
+++ b/src/graphql/user.graphql
@@ -4,3 +4,15 @@ fragment User on User {
   id
   role
 }
+
+query LoadUser($id: String!) {
+  user(id: $id) {
+    ...User
+  }
+}
+
+mutation UpdateUser($input: UpdateUserInput!) {
+  updateUser(updateUserInput: $input) {
+    ...User
+  }
+}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -33,6 +33,7 @@ export const theme = createTheme({
       styleOverrides: {
         root: {
           borderRadius: "1000px",
+          textTransform: "none",
         },
       },
     },
@@ -41,6 +42,13 @@ export const theme = createTheme({
         root: {
           borderRadius: "12px",
           boxShadow: "rgba(99, 105, 110, 0.18) 0px 1px 12px 0px",
+        },
+      },
+    },
+    MuiContainer: {
+      styleOverrides: {
+        root: {
+          marginLeft: 0,
         },
       },
     },

--- a/src/user/User.tsx
+++ b/src/user/User.tsx
@@ -17,6 +17,8 @@ import { useAdvertiser } from "auth/hooks/queries/useAdvertiser";
 import { Navbar } from "components/Navigation/Navbar";
 import { CampaignView } from "user/views/user/CampaignView";
 import { CampaignReportView } from "user/views/user/CampaignReportView";
+import MiniSideBar from "components/Drawer/MiniSideBar";
+import { Profile } from "user/views/user/Profile";
 
 const buildApolloClient = () => {
   const httpLink = createHttpLink({
@@ -68,6 +70,8 @@ export function User() {
               />
 
               <Route path="/user/main/settings" component={Settings} />
+
+              <Route path="/user/main/profile" component={Profile} />
 
               <ProtectedRoute
                 path="/user/main/campaign"

--- a/src/user/hooks/useGenerateApiKey.tsx
+++ b/src/user/hooks/useGenerateApiKey.tsx
@@ -1,0 +1,45 @@
+import { buildAdServerV2Endpoint } from "util/environment";
+import { useCallback, useState } from "react";
+
+export function useGenerateApiKey() {
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<string>();
+  const [error, setError] = useState<string>();
+
+  const generate = useCallback((advertiserId: string) => {
+    setLoading(true);
+    createKey(advertiserId)
+      .then((res) => {
+        setData(res);
+      })
+      .catch((error) => {
+        setError(error.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  return { generate, data, loading, error };
+}
+
+async function createKey(advertiserId: string): Promise<string> {
+  const res = await fetch(buildAdServerV2Endpoint("/auth/api-key"), {
+    method: "POST",
+    mode: "cors",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify({
+      advertiserId,
+    }),
+  });
+
+  if (res.status !== 200) {
+    throw new Error("cannot create key");
+  }
+
+  const { apiKey } = await res.json();
+  return apiKey;
+}

--- a/src/user/settings/NewKeyPairModal.tsx
+++ b/src/user/settings/NewKeyPairModal.tsx
@@ -1,0 +1,258 @@
+import {
+  Box,
+  Button,
+  Modal,
+  Stack,
+  SxProps,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useUpdateAdvertiserMutation } from "graphql/advertiser.generated";
+import * as tweetnacl from "tweetnacl";
+import { useState } from "react";
+import { IAdvertiser } from "auth/context/auth.interface";
+import { CardContainer } from "components/Card/CardContainer";
+
+const modalStyles: SxProps = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  right: "auto",
+  bottom: "auto",
+  transform: "translate(-50%, -50%)",
+  width: 650,
+  bgcolor: "background.paper",
+  border: "2px solid #e2e2e2",
+  boxShadow: 24,
+  borderRadius: "4px",
+  p: 4,
+};
+
+interface Props {
+  advertiser: IAdvertiser;
+}
+
+export function NewKeyPairModal({ advertiser }: Props) {
+  const [saving, setSaving] = useState(false);
+  const [publicKey, setPublicKey] = useState(advertiser.publicKey);
+  const [newPublicKey, setNewPublicKey] = useState("");
+  const [newPrivateKey, setNewPrivateKey] = useState("");
+  const [privateKey, setPrivateKey] = useState("");
+  const [showNewKeypairModal, setShowNewKeypairModal] = useState(false);
+  const [newKeypairModalState, setNewKeypairModalState] =
+    useState("disclaimer");
+
+  const [updateAdvertiser] = useUpdateAdvertiserMutation({
+    variables: {
+      updateAdvertiserInput: {
+        id: advertiser.id,
+        publicKey: publicKey,
+      },
+    },
+    onCompleted() {
+      setPublicKey(newPublicKey);
+      setPrivateKey("");
+      setNewPrivateKey("");
+      closeNewKeypairModal();
+      window.location.reload();
+    },
+    onError() {
+      alert("Unable to update Advertiser.");
+    },
+  });
+
+  const saveKeypair = () => {
+    setSaving(true);
+    updateAdvertiser({
+      variables: {
+        updateAdvertiserInput: {
+          id: advertiser.id,
+          publicKey: newPublicKey,
+        },
+      },
+    });
+  };
+
+  const openNewKeypairModal = () => {
+    const keypair = tweetnacl.box.keyPair();
+    const publicKey = btoa(
+      String.fromCharCode.apply(null, keypair.publicKey as unknown as number[]),
+    );
+    const privateKey = btoa(
+      String.fromCharCode.apply(null, keypair.secretKey as unknown as number[]),
+    );
+    setNewPublicKey(publicKey);
+    setPrivateKey(privateKey);
+    setShowNewKeypairModal(true);
+  };
+
+  const closeNewKeypairModal = () => {
+    setNewKeypairModalState("disclaimer");
+    setShowNewKeypairModal(false);
+  };
+
+  return (
+    <>
+      <CardContainer header="Account Settings">
+        <Typography variant="h6" gutterBottom>
+          Keypairs
+        </Typography>
+
+        <Typography>
+          Generate a keypair for your organization. Brave Ads will use your
+          organization's public key to sign and encrypt conversion data. Only
+          your organization will have access to the private key, which can be
+          used to decrypt and view conversion data.
+        </Typography>
+
+        {publicKey !== "" && (
+          <Box marginTop={1}>
+            <Typography>Your organization's public key:</Typography>
+            <Box component="pre" marginY={0}>
+              {publicKey}
+            </Box>
+          </Box>
+        )}
+        <Box>
+          <Button
+            onClick={() => openNewKeypairModal()}
+            variant="contained"
+            style={{
+              marginTop: "22px",
+              width: "300px",
+              alignSelf: "center",
+            }}
+          >
+            New Keypair
+          </Button>
+        </Box>
+      </CardContainer>
+
+      <Modal open={showNewKeypairModal} onClose={() => closeNewKeypairModal()}>
+        <Box sx={modalStyles}>
+          {newKeypairModalState === "disclaimer" && (
+            <Box maxWidth={600}>
+              <Typography variant="h6" color="primary" gutterBottom>
+                Create new keypair?
+              </Typography>
+
+              <Typography>
+                You are attempting to create a new keypair, this will replace
+                any of your organization's existing keypairs. Please note,
+                previous keypairs cannot be retrieved or used once replaced.
+              </Typography>
+
+              <Stack
+                direction="row"
+                spacing={2}
+                justifyContent="flex-end"
+                marginTop={4}
+              >
+                <Button variant="outlined" onClick={closeNewKeypairModal}>
+                  Cancel
+                </Button>
+
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={() => setNewKeypairModalState("privateKey")}
+                >
+                  Continue
+                </Button>
+              </Stack>
+            </Box>
+          )}
+          {newKeypairModalState === "privateKey" && (
+            <Box maxWidth={600}>
+              <Typography variant="h6" color="primary" gutterBottom>
+                Create new keypair?
+              </Typography>
+
+              <Typography gutterBottom>
+                Your organization's new private key will be:
+              </Typography>
+
+              <TextField
+                value={privateKey}
+                InputProps={{
+                  readOnly: true,
+                }}
+                fullWidth
+                sx={{ bgcolor: "#fafafa" }}
+              />
+
+              <Typography mt={2} gutterBottom>
+                Copy this and keep this safe!
+              </Typography>
+              <Typography>
+                Brave cannot recover this key, which has been generated in your
+                browser. You will need to confirm this private key on the next
+                step before changes are saved.
+              </Typography>
+              <Stack
+                direction="row"
+                spacing={2}
+                justifyContent="flex-end"
+                marginTop={4}
+              >
+                <Button variant="outlined" onClick={closeNewKeypairModal}>
+                  Cancel
+                </Button>
+
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={() => setNewKeypairModalState("confirmation")}
+                >
+                  Continue
+                </Button>
+              </Stack>
+            </Box>
+          )}
+          {newKeypairModalState === "confirmation" && (
+            <Box maxWidth={600}>
+              <Typography variant="h6" color="primary" gutterBottom>
+                Create new keypair?
+              </Typography>
+
+              <Typography gutterBottom>
+                Please confirm your organization's new private key:
+              </Typography>
+
+              <TextField
+                value={newPrivateKey}
+                fullWidth
+                onChange={(e) => setNewPrivateKey(e.target.value)}
+              />
+
+              <Typography gutterBottom marginTop={2}>
+                Once confirmed, your organization's keypair will be replaced
+                with the new keypair.
+              </Typography>
+
+              <Stack
+                direction="row"
+                spacing={2}
+                justifyContent="flex-end"
+                marginTop={4}
+              >
+                <Button variant="outlined" onClick={closeNewKeypairModal}>
+                  Cancel
+                </Button>
+
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={() => saveKeypair()}
+                  disabled={saving || privateKey !== newPrivateKey}
+                >
+                  {saving ? "Saving..." : "Save"}
+                </Button>
+              </Stack>
+            </Box>
+          )}
+        </Box>
+      </Modal>
+    </>
+  );
+}

--- a/src/user/settings/NewKeyPairModal.tsx
+++ b/src/user/settings/NewKeyPairModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { useUpdateAdvertiserMutation } from "graphql/advertiser.generated";
 import * as tweetnacl from "tweetnacl";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { IAdvertiser } from "auth/context/auth.interface";
 import { CardContainer } from "components/Card/CardContainer";
 
@@ -34,7 +34,8 @@ interface Props {
 
 export function NewKeyPairModal({ advertiser }: Props) {
   const [saving, setSaving] = useState(false);
-  const [publicKey, setPublicKey] = useState(advertiser.publicKey);
+  const publicKey = useRef<string | null>();
+  publicKey.current = advertiser.publicKey;
   const [newPublicKey, setNewPublicKey] = useState("");
   const [newPrivateKey, setNewPrivateKey] = useState("");
   const [privateKey, setPrivateKey] = useState("");
@@ -46,11 +47,11 @@ export function NewKeyPairModal({ advertiser }: Props) {
     variables: {
       updateAdvertiserInput: {
         id: advertiser.id,
-        publicKey: publicKey,
+        publicKey: publicKey.current,
       },
     },
     onCompleted() {
-      setPublicKey(newPublicKey);
+      publicKey.current = newPublicKey;
       setPrivateKey("");
       setNewPrivateKey("");
       closeNewKeypairModal();
@@ -105,11 +106,11 @@ export function NewKeyPairModal({ advertiser }: Props) {
           used to decrypt and view conversion data.
         </Typography>
 
-        {publicKey !== "" && (
+        {publicKey.current !== "" && (
           <Box marginTop={1}>
             <Typography>Your organization's public key:</Typography>
             <Box component="pre" marginY={0}>
-              {publicKey}
+              {publicKey.current}
             </Box>
           </Box>
         )}

--- a/src/user/settings/Profile.tsx
+++ b/src/user/settings/Profile.tsx
@@ -1,0 +1,1 @@
+export function Profile() {}

--- a/src/user/settings/Settings.tsx
+++ b/src/user/settings/Settings.tsx
@@ -16,7 +16,7 @@ import { setActiveAdvertiser } from "auth/util";
 import { CardContainer } from "components/Card/CardContainer";
 import { DraftContext } from "state/context";
 import { NewKeyPairModal } from "user/settings/NewKeyPairModal";
-import { DashboardButton } from "components/Button/DashboardButton";
+import MiniSideBar from "components/Drawer/MiniSideBar";
 
 const Settings = () => {
   const { advertiser: activeAdvertiser, advertisers } = useAdvertiser();
@@ -26,6 +26,7 @@ const Settings = () => {
   const setActiveAdvertiserWithId = (e: SelectChangeEvent) => {
     const id = e.target.value;
     const adv = _.find(advertisers, { id });
+    console.log(adv);
 
     if (adv) {
       setAdvertiser(adv);
@@ -35,36 +36,37 @@ const Settings = () => {
   };
 
   return (
-    <Container>
-      <DashboardButton />
-      <Stack spacing={2} mt={1}>
-        <NewKeyPairModal advertiser={advertiser} />
+    <MiniSideBar>
+      <Container>
+        <Stack spacing={2} mt={1}>
+          <NewKeyPairModal advertiser={advertiser} />
 
-        <CardContainer header="Organization">
-          <Typography>
-            You may have access to multiple organisations. Switch between them
-            here.
-          </Typography>
+          <CardContainer header="Organization">
+            <Typography>
+              You may have access to multiple organisations. Switch between them
+              here.
+            </Typography>
 
-          <Box sx={{ mt: 2 }}>
-            <FormControl fullWidth>
-              <InputLabel>Select Organization</InputLabel>
-              <Select
-                value={advertiser.id}
-                label="Select Organization"
-                onChange={(e) => setActiveAdvertiserWithId(e)}
-              >
-                {advertisers.map((a) => (
-                  <MenuItem key={a.id} value={a.id}>
-                    {a.name}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Box>
-        </CardContainer>
-      </Stack>
-    </Container>
+            <Box sx={{ mt: 2 }}>
+              <FormControl fullWidth>
+                <InputLabel>Select Organization</InputLabel>
+                <Select
+                  value={advertiser.id}
+                  label="Select Organization"
+                  onChange={(e) => setActiveAdvertiserWithId(e)}
+                >
+                  {advertisers.map((a) => (
+                    <MenuItem key={a.id} value={a.id}>
+                      {a.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+          </CardContainer>
+        </Stack>
+      </Container>
+    </MiniSideBar>
   );
 };
 

--- a/src/user/settings/Settings.tsx
+++ b/src/user/settings/Settings.tsx
@@ -1,163 +1,44 @@
-import { useContext, useState } from "react";
+import React, { useContext, useState } from "react";
 import _ from "lodash";
-import * as tweetnacl from "tweetnacl";
-import { useUpdateAdvertiserMutation } from "graphql/advertiser.generated";
 import {
   Box,
-  Button,
   Container,
   FormControl,
   InputLabel,
   MenuItem,
-  Modal,
   Select,
   SelectChangeEvent,
   Stack,
-  SxProps,
-  TextField,
   Typography,
 } from "@mui/material";
 import { useAdvertiser } from "auth/hooks/queries/useAdvertiser";
 import { setActiveAdvertiser } from "auth/util";
-import ArrowBack from "@mui/icons-material/ArrowBack";
-import { useHistory } from "react-router-dom";
 import { CardContainer } from "components/Card/CardContainer";
 import { DraftContext } from "state/context";
-
-const modalStyles: SxProps = {
-  position: "absolute",
-  top: "50%",
-  left: "50%",
-  right: "auto",
-  bottom: "auto",
-  transform: "translate(-50%, -50%)",
-  width: 650,
-  bgcolor: "background.paper",
-  border: "2px solid #e2e2e2",
-  boxShadow: 24,
-  borderRadius: "4px",
-  p: 4,
-};
+import { NewKeyPairModal } from "user/settings/NewKeyPairModal";
+import { DashboardButton } from "components/Button/DashboardButton";
 
 const Settings = () => {
   const { advertiser: activeAdvertiser, advertisers } = useAdvertiser();
-  const [saving, setSaving] = useState(false);
-  const [publicKey, setPublicKey] = useState(activeAdvertiser.publicKey);
-  const [advertiserId, setAdvertiserId] = useState(activeAdvertiser.id);
-  const [newPublicKey, setNewPublicKey] = useState("");
-  const [newPrivateKey, setNewPrivateKey] = useState("");
-  const [privateKey, setPrivateKey] = useState("");
-  const [showNewKeypairModal, setShowNewKeypairModal] = useState(false);
-  const [newKeypairModalState, setNewKeypairModalState] =
-    useState("disclaimer");
+  const [advertiser, setAdvertiser] = useState(activeAdvertiser);
   const { setDrafts } = useContext(DraftContext);
-  const history = useHistory();
-
-  const handleUpdateAdvertiser = () => {
-    setSaving(false);
-    setPublicKey(newPublicKey);
-    setPrivateKey("");
-    setNewPrivateKey("");
-    closeNewKeypairModal();
-    window.location.reload();
-  };
-
-  const [updateAdvertiser] = useUpdateAdvertiserMutation({
-    variables: {
-      updateAdvertiserInput: {
-        id: advertiserId,
-        publicKey: publicKey,
-      },
-    },
-    onCompleted: handleUpdateAdvertiser,
-    onError() {
-      alert("Unable to update Advertiser.");
-    },
-  });
-
-  const saveKeypair = () => {
-    setSaving(true);
-    updateAdvertiser({
-      variables: {
-        updateAdvertiserInput: {
-          id: advertiserId,
-          publicKey: newPublicKey,
-        },
-      },
-    });
-  };
-
-  const openNewKeypairModal = () => {
-    const keypair = tweetnacl.box.keyPair();
-    const publicKey = btoa(
-      String.fromCharCode.apply(null, keypair.publicKey as unknown as number[]),
-    );
-    const privateKey = btoa(
-      String.fromCharCode.apply(null, keypair.secretKey as unknown as number[]),
-    );
-    setNewPublicKey(publicKey);
-    setPrivateKey(privateKey);
-    setShowNewKeypairModal(true);
-  };
-
-  const closeNewKeypairModal = () => {
-    setNewKeypairModalState("disclaimer");
-    setShowNewKeypairModal(false);
-  };
 
   const setActiveAdvertiserWithId = (e: SelectChangeEvent) => {
     const id = e.target.value;
-    setAdvertiserId(id);
     const adv = _.find(advertisers, { id });
-    setPublicKey(adv?.publicKey);
-    setActiveAdvertiser(adv?.id);
-    setDrafts();
+
+    if (adv) {
+      setAdvertiser(adv);
+      setActiveAdvertiser(adv?.id);
+      setDrafts();
+    }
   };
 
   return (
     <Container>
-      <Button
-        variant="text"
-        startIcon={<ArrowBack />}
-        onClick={() => history.replace("/user/main")}
-      >
-        Dashboard
-      </Button>
+      <DashboardButton />
       <Stack spacing={2} mt={1}>
-        <CardContainer header="Account Settings">
-          <Typography variant="h6" gutterBottom>
-            Keypairs
-          </Typography>
-
-          <Typography>
-            Generate a keypair for your organization. Brave Ads will use your
-            organization's public key to sign and encrypt conversion data. Only
-            your organization will have access to the private key, which can be
-            used to decrypt and view conversion data.
-          </Typography>
-
-          {publicKey !== "" && (
-            <Box marginTop={1}>
-              <Typography>Your organization's public key:</Typography>
-              <Box component="pre" marginY={0}>
-                {publicKey}
-              </Box>
-            </Box>
-          )}
-          <Box>
-            <Button
-              onClick={() => openNewKeypairModal()}
-              variant="contained"
-              style={{
-                marginTop: "22px",
-                width: "300px",
-                alignSelf: "center",
-              }}
-            >
-              New Keypair
-            </Button>
-          </Box>
-        </CardContainer>
+        <NewKeyPairModal advertiser={advertiser} />
 
         <CardContainer header="Organization">
           <Typography>
@@ -169,7 +50,7 @@ const Settings = () => {
             <FormControl fullWidth>
               <InputLabel>Select Organization</InputLabel>
               <Select
-                value={advertiserId}
+                value={advertiser.id}
                 label="Select Organization"
                 onChange={(e) => setActiveAdvertiserWithId(e)}
               >
@@ -183,132 +64,6 @@ const Settings = () => {
           </Box>
         </CardContainer>
       </Stack>
-
-      <Modal open={showNewKeypairModal} onClose={() => closeNewKeypairModal()}>
-        <Box sx={modalStyles}>
-          {newKeypairModalState === "disclaimer" && (
-            <Box maxWidth={600}>
-              <Typography variant="h6" color="primary" gutterBottom>
-                Create new keypair?
-              </Typography>
-
-              <Typography>
-                You are attempting to create a new keypair, this will replace
-                any of your organization's existing keypairs. Please note,
-                previous keypairs cannot be retrieved or used once replaced.
-              </Typography>
-
-              <Stack
-                direction="row"
-                spacing={2}
-                justifyContent="flex-end"
-                marginTop={4}
-              >
-                <Button variant="outlined" onClick={closeNewKeypairModal}>
-                  Cancel
-                </Button>
-
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={() => setNewKeypairModalState("privateKey")}
-                >
-                  Continue
-                </Button>
-              </Stack>
-            </Box>
-          )}
-          {newKeypairModalState === "privateKey" && (
-            <Box maxWidth={600}>
-              <Typography variant="h6" color="primary" gutterBottom>
-                Create new keypair?
-              </Typography>
-
-              <Typography gutterBottom>
-                Your organization's new private key will be:
-              </Typography>
-
-              <TextField
-                value={privateKey}
-                InputProps={{
-                  readOnly: true,
-                }}
-                fullWidth
-                sx={{ bgcolor: "#fafafa" }}
-              />
-
-              <Typography mt={2} gutterBottom>
-                Copy this and keep this safe!
-              </Typography>
-              <Typography>
-                Brave cannot recover this key, which has been generated in your
-                browser. You will need to confirm this private key on the next
-                step before changes are saved.
-              </Typography>
-              <Stack
-                direction="row"
-                spacing={2}
-                justifyContent="flex-end"
-                marginTop={4}
-              >
-                <Button variant="outlined" onClick={closeNewKeypairModal}>
-                  Cancel
-                </Button>
-
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={() => setNewKeypairModalState("confirmation")}
-                >
-                  Continue
-                </Button>
-              </Stack>
-            </Box>
-          )}
-          {newKeypairModalState === "confirmation" && (
-            <Box maxWidth={600}>
-              <Typography variant="h6" color="primary" gutterBottom>
-                Create new keypair?
-              </Typography>
-
-              <Typography gutterBottom>
-                Please confirm your organization's new private key:
-              </Typography>
-
-              <TextField
-                value={newPrivateKey}
-                fullWidth
-                onChange={(e) => setNewPrivateKey(e.target.value)}
-              />
-
-              <Typography gutterBottom marginTop={2}>
-                Once confirmed, your organization's keypair will be replaced
-                with the new keypair.
-              </Typography>
-
-              <Stack
-                direction="row"
-                spacing={2}
-                justifyContent="flex-end"
-                marginTop={4}
-              >
-                <Button variant="outlined" onClick={closeNewKeypairModal}>
-                  Cancel
-                </Button>
-
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={() => saveKeypair()}
-                  disabled={saving || privateKey !== newPrivateKey}
-                >
-                  {saving ? "Saving..." : "Save"}
-                </Button>
-              </Stack>
-            </Box>
-          )}
-        </Box>
-      </Modal>
     </Container>
   );
 };

--- a/src/user/settings/Settings.tsx
+++ b/src/user/settings/Settings.tsx
@@ -26,7 +26,6 @@ const Settings = () => {
   const setActiveAdvertiserWithId = (e: SelectChangeEvent) => {
     const id = e.target.value;
     const adv = _.find(advertisers, { id });
-    console.log(adv);
 
     if (adv) {
       setAdvertiser(adv);

--- a/src/user/settings/UserApiKey.tsx
+++ b/src/user/settings/UserApiKey.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import { CardContainer } from "components/Card/CardContainer";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Link,
+  Typography,
+} from "@mui/material";
+import { LoadingButton } from "@mui/lab";
+import { useAdvertiser } from "auth/hooks/queries/useAdvertiser";
+import { useGenerateApiKey } from "user/hooks/useGenerateApiKey";
+import ContentCopyOutlinedIcon from "@mui/icons-material/ContentCopyOutlined";
+
+export function UserApiKey() {
+  const { advertiser } = useAdvertiser();
+  const { generate, data, loading } = useGenerateApiKey();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <CardContainer header="Profile API Key">
+      <Typography>
+        API keys are used to get data from the reporting endpoints. They are
+        unique to you.
+      </Typography>
+
+      <div style={{ margin: "10px" }} />
+
+      <Typography>
+        Documentation can be found{" "}
+        <Link
+          href="https://github.com/brave/ads-ui/wiki/Brave-Ads-Advertiser-API-Guide"
+          underline="none"
+        >
+          here
+        </Link>{" "}
+        on how to use the API.
+      </Typography>
+
+      <div style={{ margin: "10px" }} />
+
+      <Button onClick={() => setOpen(true)} variant="contained" size="large">
+        Generate API Key
+      </Button>
+
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="lg">
+        <DialogTitle>
+          {data ? "New API Key" : "Generate a new API key?"}
+        </DialogTitle>
+        <DialogContent>
+          {!data && (
+            <DialogContentText>
+              Generating a new API key will result in the deactivation of your
+              previous key, rendering it unusable for future requests. Make sure
+              to update your code with the new key to avoid disruptions in your
+              application's functionality.
+            </DialogContentText>
+          )}
+          {data && (
+            <Box>
+              <DialogContentText>
+                This key is unique to you, make sure to safely store it and
+                avoid sharing it with others to prevent unauthorized access.
+              </DialogContentText>
+              <Box
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+                component={Typography}
+                bgcolor="#ededed"
+                borderRadius={"16px"}
+                mt={1}
+                padding={1}
+              >
+                {data}
+                <IconButton
+                  onClick={() =>
+                    window.navigator.clipboard
+                      .writeText(data)
+                      .then(() => alert("Key copied"))
+                  }
+                  sx={{ ml: 1 }}
+                >
+                  <ContentCopyOutlinedIcon />
+                </IconButton>
+              </Box>
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>
+            {data ? "Close" : "Cancel"}
+          </Button>
+          {!data && (
+            <LoadingButton
+              disabled={loading}
+              loading={loading}
+              onClick={() => generate(advertiser.id)}
+            >
+              Generate
+            </LoadingButton>
+          )}
+        </DialogActions>
+      </Dialog>
+    </CardContainer>
+  );
+}

--- a/src/user/settings/UserForm.tsx
+++ b/src/user/settings/UserForm.tsx
@@ -1,0 +1,68 @@
+import { Stack } from "@mui/material";
+import React, { useState } from "react";
+import { useUser } from "auth/hooks/queries/useUser";
+import { CardContainer } from "components/Card/CardContainer";
+import { Form, Formik, FormikValues } from "formik";
+import { FormikSubmitButton, FormikTextField } from "form/FormikHelpers";
+import { useUpdateUserMutation } from "graphql/user.generated";
+import { ErrorDetail } from "components/Error/ErrorDetail";
+import { UserSchema } from "validation/UserSchema";
+import _ from "lodash";
+
+export function UserForm() {
+  const user = useUser();
+  const [initialVals, setInitialVals] = useState(user);
+
+  if (!user.userId) {
+    const details = "Unable to get user information";
+    return <ErrorDetail error={details} additionalDetails={details} />;
+  }
+
+  const [updateUser] = useUpdateUserMutation({
+    onCompleted(user) {
+      setInitialVals(user.updateUser);
+    },
+  });
+
+  return (
+    <CardContainer header="User Details">
+      <Formik
+        enableReinitialize
+        initialValues={initialVals}
+        onSubmit={(v, { setSubmitting }: FormikValues) => {
+          setSubmitting(true);
+          updateUser({
+            variables: { input: { id: user.userId, ..._.omit(v, ["userId"]) } },
+          }).finally(() => setSubmitting(false));
+        }}
+        validationSchema={UserSchema}
+      >
+        <Form>
+          <Stack direction="row" spacing={2}>
+            <FormikTextField
+              name="email"
+              label="Email"
+              type="email"
+              margin="none"
+            />
+            <FormikTextField
+              name="password"
+              label="Password"
+              type="password"
+              margin="none"
+            />
+          </Stack>
+          <Stack direction="row" spacing={2} mt={2} mb={1}>
+            <FormikTextField
+              name="fullName"
+              label="Full Name"
+              type="text"
+              margin="none"
+            />
+          </Stack>
+          <FormikSubmitButton isCreate={false} />
+        </Form>
+      </Formik>
+    </CardContainer>
+  );
+}

--- a/src/user/settings/UserForm.tsx
+++ b/src/user/settings/UserForm.tsx
@@ -14,7 +14,7 @@ export function UserForm() {
   const [initialVals, setInitialVals] = useState(user);
 
   if (!user.userId) {
-    const details = "Unable to get user information";
+    const details = "Unable to get profile information";
     return <ErrorDetail error={details} additionalDetails={details} />;
   }
 
@@ -25,7 +25,7 @@ export function UserForm() {
   });
 
   return (
-    <CardContainer header="User Details">
+    <CardContainer header="Profile Details">
       <Formik
         enableReinitialize
         initialValues={initialVals}

--- a/src/user/views/user/CampaignView.tsx
+++ b/src/user/views/user/CampaignView.tsx
@@ -6,6 +6,7 @@ import { CampaignList } from "user/campaignList/CampaignList";
 import { ErrorDetail } from "components/Error/ErrorDetail";
 import moment from "moment/moment";
 import { CardContainer } from "components/Card/CardContainer";
+import MiniSideBar from "components/Drawer/MiniSideBar";
 
 export function CampaignView() {
   const [fromDateFilter, setFromDateFilter] = useState<Date | null>(
@@ -31,9 +32,13 @@ export function CampaignView() {
   }
 
   return (
-    <Box display="flex" flexDirection="column" sx={{ mb: 2, ml: 2, mr: 2 }}>
+    <MiniSideBar>
       <CardContainer
         header="Campaigns"
+        sx={{
+          flexGrow: 1,
+          mr: 2,
+        }}
         additionalAction={
           <CampaignAgeFilter
             fromDate={fromDateFilter}
@@ -53,6 +58,6 @@ export function CampaignView() {
           </Box>
         )}
       </CardContainer>
-    </Box>
+    </MiniSideBar>
   );
 }

--- a/src/user/views/user/Profile.tsx
+++ b/src/user/views/user/Profile.tsx
@@ -1,0 +1,13 @@
+import { Container } from "@mui/material";
+import { UserForm } from "user/settings/UserForm";
+import { DashboardButton } from "components/Button/DashboardButton";
+
+export function Profile() {
+  return (
+    <Container>
+      <div style={{ marginTop: "10px" }} />
+      <DashboardButton />
+      <UserForm />
+    </Container>
+  );
+}

--- a/src/user/views/user/Profile.tsx
+++ b/src/user/views/user/Profile.tsx
@@ -1,13 +1,17 @@
 import { Container } from "@mui/material";
 import { UserForm } from "user/settings/UserForm";
-import { DashboardButton } from "components/Button/DashboardButton";
+import { UserApiKey } from "user/settings/UserApiKey";
+import MiniSideBar from "components/Drawer/MiniSideBar";
 
 export function Profile() {
   return (
-    <Container>
-      <div style={{ marginTop: "10px" }} />
-      <DashboardButton />
-      <UserForm />
-    </Container>
+    <MiniSideBar>
+      <Container>
+        <div style={{ marginTop: "10px" }} />
+        <UserForm />
+        <div style={{ marginBottom: "40px" }} />
+        <UserApiKey />
+      </Container>
+    </MiniSideBar>
   );
 }

--- a/src/validation/UserSchema.test.ts
+++ b/src/validation/UserSchema.test.ts
@@ -3,6 +3,7 @@ import { produce } from "immer";
 
 const validUser = {
   email: "test@brave.com",
+  fullName: "Test User",
 };
 
 it("should pass on a valid object", () => {

--- a/src/validation/UserSchema.test.ts
+++ b/src/validation/UserSchema.test.ts
@@ -1,0 +1,18 @@
+import { UserSchema } from "./UserSchema";
+import { produce } from "immer";
+
+const validUser = {
+  email: "test@brave.com",
+};
+
+it("should pass on a valid object", () => {
+  UserSchema.validateSync(validUser);
+});
+
+it("should fail if the campaign format is invalid", () => {
+  const c = produce(validUser, (draft) => {
+    draft.email = "";
+  });
+
+  expect(() => UserSchema.validateSync(c)).toThrowError();
+});

--- a/src/validation/UserSchema.tsx
+++ b/src/validation/UserSchema.tsx
@@ -1,0 +1,6 @@
+import { object, string } from "yup";
+
+export const UserSchema = object().shape({
+  email: string().label("Email").required(),
+  fullName: string().label("Full Name").required(),
+});


### PR DESCRIPTION
Front end portion of: https://github.com/brave/ads-serve/issues/3049
As well as meets partial goal of: https://github.com/brave/roadmap/issues/838

Allows user to update their email and add password, as well as create an API key to use advertiser API.

---


https://github.com/brave/ads-ui/assets/48930920/91f7623e-53d1-4691-a13c-5673b2c13678

---


![Screen Shot 2023-08-08 at 5 00 25 PM](https://github.com/brave/ads-ui/assets/48930920/d689a7ef-5cbf-4f81-b75e-2a3c1014d1de)

