### PR TITLE
fix: add new support resources

### DIFF
--- a/src/auth/views/LandingPage.tsx
+++ b/src/auth/views/LandingPage.tsx
@@ -1,6 +1,6 @@
 import { Background } from "components/Background/Background";
 import { LandingPageAppBar } from "components/AppBar/LandingPageAppBar";
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button, Link, Stack, Typography } from "@mui/material";
 import goals from "../../../images.svg";
 import { useIsAuthenticated } from "auth/hooks/queries/useIsAuthenticated";
 import { Link as RouterLink } from "react-router-dom";
@@ -37,20 +37,36 @@ export function LandingPage() {
             Brave browser and search engine.
           </Typography>
 
-          <Box>
+          <Box display="flex" flexDirection="column">
             <Button
               variant="contained"
               component={RouterLink}
               sx={{
-                width: "Hug (165px)",
-                height: "Fixed (60px)",
+                maxWidth: "165px",
+                height: "60px",
                 padding: "18px 24px 18px 24px",
+                mb: 1,
               }}
               size="large"
               to={isAuthenticated ? "/user/main" : "/register"}
             >
               {isAuthenticated ? "Dashboard" : "Get Started"}
             </Button>
+            {!isAuthenticated && (
+              <Typography variant="subtitle1">
+                Already have an account?
+                <Link
+                  variant="subtitle1"
+                  underline="none"
+                  color="secondary"
+                  component={RouterLink}
+                  to="/auth/link"
+                  sx={{ ml: 1 }}
+                >
+                  Log in
+                </Link>
+              </Typography>
+            )}
           </Box>
         </Stack>
         <img src={goals} />

--- a/src/components/AppBar/LandingPageAppBar.tsx
+++ b/src/components/AppBar/LandingPageAppBar.tsx
@@ -14,6 +14,7 @@ import ads from "../../../branding.svg";
 import { Link as RouterLink, useRouteMatch } from "react-router-dom";
 import { useIsAuthenticated } from "auth/hooks/queries/useIsAuthenticated";
 import { useSignOut } from "auth/hooks/mutations/useSignOut";
+import { SupportMenu } from "components/Drawer/MiniSideBar";
 
 export function LandingPageAppBar() {
   const match = useRouteMatch();
@@ -41,12 +42,7 @@ export function LandingPageAppBar() {
       ),
     },
     {
-      component: (
-        <HelpLink
-          label="Support"
-          props={{ href: "mailto:selfserve@brave.com" }}
-        />
-      ),
+      component: <SupportMenu usePlainLink />,
     },
   ];
 

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -165,27 +165,46 @@ const ItemBox = (props: RouteOption) => {
   );
 };
 
-export function SupportMenu() {
+interface SupportProps {
+  usePlainLink?: boolean;
+}
+
+export function SupportMenu({ usePlainLink }: SupportProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleClick = (
+    event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>,
+  ) => {
     setAnchorEl(event.currentTarget);
   };
 
   return (
     <>
-      <ItemBox
-        label="Support"
-        href="#"
-        icon={
-          <HeadsetMicOutlinedIcon
-            fontSize="large"
-            sx={{ color: "text.secondary" }}
-          />
-        }
-        onClick={handleClick}
-      />
+      {!usePlainLink && (
+        <ItemBox
+          label="Support"
+          href="#"
+          icon={
+            <HeadsetMicOutlinedIcon
+              fontSize="large"
+              sx={{ color: "text.secondary" }}
+            />
+          }
+          onClick={handleClick}
+        />
+      )}
+      {usePlainLink && (
+        <Link
+          variant="subtitle1"
+          underline="none"
+          color="text.primary"
+          sx={{ cursor: "pointer" }}
+          onClick={handleClick}
+        >
+          Support
+        </Link>
+      )}
       <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
         <MenuItem
           onClick={() => {

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -189,6 +189,18 @@ export function SupportMenu() {
       <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
         <MenuItem
           onClick={() => {
+            window.open(
+              "https://support.brave.com/hc/en-us/articles/14354133537421-How-do-I-use-Brave-Ads-Self-Serve-Beta-",
+              "_blank",
+              "noopener",
+            );
+            setAnchorEl(null);
+          }}
+        >
+          Brave Ads Tutorial
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
             window.open("https://brave.com/brave-ads", "_blank", "noopener");
             setAnchorEl(null);
           }}


### PR DESCRIPTION
Shares support menu, adds new resource, and makes it more obvious what to do if existing advertiser

---

![Screen Shot 2023-08-15 at 12 55 32 PM](https://github.com/brave/ads-ui/assets/48930920/10e5d1d1-81d5-4659-8a5e-cc4debb10a2a)
