### PR TITLE
fix: correctly include createdAt

### DIFF
--- a/src/user/hooks/useAdvertiserCreatives.ts
+++ b/src/user/hooks/useAdvertiserCreatives.ts
@@ -12,6 +12,7 @@ export function useAdvertiserCreatives() {
       advertiserId: c.advertiserId,
       name: c.name,
       state: c.state,
+      createdAt: c.createdAt,
       included: false,
     }),
   );

--- a/src/user/library/index.test.ts
+++ b/src/user/library/index.test.ts
@@ -449,6 +449,7 @@ describe("edit form tests", () => {
             "creatives": [
               {
                 "advertiserId": "12345",
+                "createdAt": undefined,
                 "id": "1234",
                 "included": true,
                 "name": "a creative",
@@ -465,6 +466,7 @@ describe("edit form tests", () => {
               },
               {
                 "advertiserId": "12345",
+                "createdAt": undefined,
                 "id": "1235",
                 "included": false,
                 "name": "a different creative",
@@ -501,6 +503,7 @@ describe("edit form tests", () => {
             "creatives": [
               {
                 "advertiserId": "12345",
+                "createdAt": undefined,
                 "id": "1234",
                 "included": true,
                 "name": "a creative",
@@ -517,6 +520,7 @@ describe("edit form tests", () => {
               },
               {
                 "advertiserId": "12345",
+                "createdAt": undefined,
                 "id": "1235",
                 "included": true,
                 "name": "a different creative",

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -175,6 +175,7 @@ function creativeList(
         const c = ad.creative;
         return {
           ...validCreativeFields(c, advertiserId, included),
+          createdAt: c.createdAt,
         };
       });
   };


### PR DESCRIPTION
Makes sure createdAt shows correctly on `AdSetAds` screen

## Before

![Screen Shot 2023-09-05 at 9 30 45 AM](https://github.com/brave/ads-ui/assets/48930920/48124a56-500b-4819-b704-eb66cf6d5779)

## After

![Screen Shot 2023-09-05 at 9 31 04 AM](https://github.com/brave/ads-ui/assets/48930920/4eb4b6a1-4b03-48d8-8306-8a4e5d10fb85)

