### PR TITLE
fix: allow new ad sets in edit view

### DIFF
--- a/src/user/library/index.test.ts
+++ b/src/user/library/index.test.ts
@@ -567,6 +567,7 @@ describe("edit form tests", () => {
                 "name": "macos",
               },
             ],
+            "perDay": 4,
             "price": "6",
             "segments": [
               {
@@ -574,6 +575,7 @@ describe("edit form tests", () => {
                 "name": "test",
               },
             ],
+            "totalMax": 28,
           },
           {
             "ads": [
@@ -592,6 +594,7 @@ describe("edit form tests", () => {
                 "name": "linux",
               },
             ],
+            "perDay": 4,
             "price": "6",
             "segments": [
               {
@@ -599,6 +602,7 @@ describe("edit form tests", () => {
                 "name": "help",
               },
             ],
+            "totalMax": 28,
           },
         ],
         "budget": 100,

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -49,16 +49,10 @@ export function transformNewForm(
     state: form.state,
     type: form.type,
     budget: form.budget,
-    adSets: form.adSets.map((adSet) => ({
-      name: adSet.name,
-      price: transformPrice(form),
-      billingType: form.billingType,
-      perDay: form.format === CampaignFormat.PushNotification ? 4 : 6,
-      segments: adSet.segments.map((s) => ({ code: s.code, name: s.name })),
-      oses: adSet.oses,
-      totalMax: form.format === CampaignFormat.PushNotification ? 28 : 60,
-      conversions: transformConversion(adSet.conversions),
-      ads: adSet.creatives
+    adSets: form.adSets.map((a) => ({
+      ...transformAdSet(a, form),
+      conversions: transformConversion(a.conversions),
+      ads: a.creatives
         .filter((c) => c.included)
         .map((ad) => ({ creativeId: ad.id })),
     })),
@@ -220,11 +214,7 @@ export function transformEditForm(
     paymentType: form.paymentType,
     adSets: form.adSets.map((adSet) => ({
       id: adSet.id,
-      billingType: form.billingType,
-      price: transformPrice(form),
-      name: adSet.name,
-      segments: adSet.segments.map((v) => ({ code: v.code, name: v.name })),
-      oses: adSet.oses.map((v) => ({ code: v.code, name: v.name })),
+      ...transformAdSet(adSet, form),
       ads: adSet.creatives
         .filter((c) => c.included)
         .map((ad) => ({
@@ -233,6 +223,21 @@ export function transformEditForm(
           creativeSetId: adSet.id,
         })),
     })),
+  };
+}
+
+function transformAdSet(
+  adSet: AdSetForm,
+  campaign: Pick<CampaignForm, "format" | "billingType" | "price">,
+) {
+  return {
+    name: adSet.name,
+    price: transformPrice(campaign),
+    billingType: campaign.billingType,
+    perDay: campaign.format === CampaignFormat.PushNotification ? 4 : 6,
+    segments: adSet.segments.map((s) => ({ code: s.code, name: s.name })),
+    oses: adSet.oses.map((s) => ({ code: s.code, name: s.name })),
+    totalMax: campaign.format === CampaignFormat.PushNotification ? 28 : 60,
   };
 }
 

--- a/src/user/views/adsManager/views/advanced/components/adSet/NewAdSet.tsx
+++ b/src/user/views/adsManager/views/advanced/components/adSet/NewAdSet.tsx
@@ -12,12 +12,10 @@ import { Link as RouterLink, useHistory } from "react-router-dom";
 import { CampaignForm, initialAdSet } from "user/views/adsManager/types";
 import { useRef } from "react";
 import RemoveCircleOutlineIcon from "@mui/icons-material/RemoveCircleOutline";
-import { useIsEdit } from "form/FormikHelpers";
 import { useAdvertiserCreatives } from "user/hooks/useAdvertiserCreatives";
 
 export function NewAdSet() {
   const { creatives } = useAdvertiserCreatives();
-  const { isEdit } = useIsEdit();
   const history = useHistory();
   const { values } = useFormikContext<CampaignForm>();
   const params = new URLSearchParams(history.location.search);
@@ -78,7 +76,7 @@ export function NewAdSet() {
                 )}
               </Stack>
             ))}
-            {values.adSets.length <= 4 && !isEdit && (
+            {values.adSets.length <= 4 && (
               <Box
                 width="100%"
                 pb={0}

--- a/src/user/views/adsManager/views/advanced/components/campaign/fields/FormatField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/fields/FormatField.tsx
@@ -70,7 +70,6 @@ const FormatItemButton = (props: { format: CampaignFormat } & PriceProps) => {
             p.billingType === bMeta.value.toUpperCase()
           );
         });
-        console.log(found);
         if (props.format === CampaignFormat.NewsDisplayAd) {
           price.setValue(found?.billingModelPrice ?? "10");
           billing.setValue("cpm");

--- a/src/util/displayState.ts
+++ b/src/util/displayState.ts
@@ -6,8 +6,6 @@ export const displayFromCampaignState = (c: {
   campaignStart: string;
   state?: string | null;
 }) => {
-  console.log(c.state);
-
   if (c.campaignState === "draft") {
     return "draft";
   } else if (isBeforeStartDate(c.campaignStart)) {


### PR DESCRIPTION
Allows adding a new ad set in the edit view. Backend work was completed for this not too long ago, can now update here.

---

https://github.com/brave/ads-ui/assets/48930920/a0cadefc-9484-4d2a-a3b7-5c4d120dc262