### PR TITLE
fix: show dash when no data for all cases

### DIFF
--- a/src/user/analytics/renderers/index.tsx
+++ b/src/user/analytics/renderers/index.tsx
@@ -45,7 +45,7 @@ export const renderEngagementCell = (
   }
 
   if (!map || !val) {
-    return <Box>N/A</Box>;
+    return <Box>-</Box>;
   }
 
   return <Box>{val[type].toLocaleString()}</Box>;
@@ -61,11 +61,7 @@ export const renderStatsCell = (
     return <Skeleton />;
   }
 
-  if (!val) {
-    return <Box>N/A</Box>;
-  }
-
-  if (val[type] <= 0) {
+  if (!val || val[type] <= 0) {
     return <Box>-</Box>;
   }
 


### PR DESCRIPTION
Makes data display in tables consistent

---

![Screen Shot 2023-10-04 at 11 12 23 AM](https://github.com/brave/ads-ui/assets/48930920/8d28d30e-f502-45bd-bf28-07596764d3cb)
