### PR TITLE
fix: pin settings to bottom bar

### DIFF
--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -31,7 +31,7 @@ type RouteOption = {
   onClick?: (event: MouseEvent<any>) => void;
 };
 
-const drawerWidth = 100;
+const drawerWidth = 85;
 export default function MiniSideBar({ children }: PropsWithChildren) {
   const { advertiser } = useAdvertiser();
   const dashboardRoutes: RouteOption[] = [
@@ -169,7 +169,9 @@ const ItemBox = (props: RouteOption) => {
     >
       <ListItemIcon sx={{ minWidth: "unset" }}>{props.icon}</ListItemIcon>
       <ListItemText disableTypography>
-        <Typography textAlign="center">{props.label}</Typography>
+        <Typography textAlign="center" variant="caption" fontWeight={500}>
+          {props.label}
+        </Typography>
       </ListItemText>
     </ListItemButton>
   );

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -104,7 +104,7 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
   ];
 
   return (
-    <Box sx={{ display: "flex" }}>
+    <Box display="flex">
       <Drawer
         variant="permanent"
         open
@@ -113,27 +113,36 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
         }}
       >
         <Toolbar />
-        <List>
-          {dashboardRoutes.map((dr) => (
-            <ItemBox
-              key={dr.href}
-              href={dr.href}
-              icon={dr.icon}
-              label={dr.label}
-              disabled={dr.disabled}
-            />
-          ))}
-          <Divider sx={{ mt: 3, mb: 3 }} />
-          {settingsRoutes.map((sr) => (
-            <ItemBox
-              href={sr.href}
-              icon={sr.icon}
-              label={sr.label}
-              key={sr.href}
-            />
-          ))}
-          <SupportMenu />
-        </List>
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          flexDirection="column"
+          flexGrow={1}
+        >
+          <List>
+            {dashboardRoutes.map((dr) => (
+              <ItemBox
+                key={dr.href}
+                href={dr.href}
+                icon={dr.icon}
+                label={dr.label}
+                disabled={dr.disabled}
+              />
+            ))}
+          </List>
+          <List>
+            <Divider sx={{ mt: 3, mb: 3 }} />
+            {settingsRoutes.map((sr) => (
+              <ItemBox
+                href={sr.href}
+                icon={sr.icon}
+                label={sr.label}
+                key={sr.href}
+              />
+            ))}
+            <SupportMenu />
+          </List>
+        </Box>
       </Drawer>
       {children}
     </Box>

--- a/src/user/views/adsManager/views/advanced/components/adSet/NewAdSet.tsx
+++ b/src/user/views/adsManager/views/advanced/components/adSet/NewAdSet.tsx
@@ -74,7 +74,7 @@ export function NewAdSet() {
                 )}
               </Stack>
             ))}
-            {values.adSets.length <= 4 && (
+            {values.adSets.length <= 19 && (
               <Box
                 width="100%"
                 pb={0}


### PR DESCRIPTION
Pins settings to bottom, so that if missing features it is less apparent

---

![Screen Shot 2023-10-04 at 4 45 59 PM](https://github.com/brave/ads-ui/assets/48930920/91160fa0-a2bd-4e0b-8b76-70bccc5c2c98)

