### PR TITLE
chore: remove fields from queries not required by the code

### DIFF
--- a/src/form/fragmentUtil.ts
+++ b/src/form/fragmentUtil.ts
@@ -54,18 +54,13 @@ export function createAdSetFromFragment(
       creativeId: ad.creative.id,
     })),
     price: ads[0].price ?? "6",
-    bannedKeywords: data.bannedKeywords,
     billingType: data.billingType ?? "cpm",
     conversions: (data.conversions ?? []).map((c) => ({
       observationWindow: c.observationWindow,
       type: c.type,
       urlPattern: c.urlPattern,
     })),
-    execution: data.execution,
-    keywordSimilarity: data.keywordSimilarity,
-    keywords: data.keywords,
     name: `${data.name ? data.name : data.id.split("-")[0]} - Copy`,
-    negativeKeywords: data.negativeKeywords,
     oses: (data.oses ?? []).map((o) => ({ name: o.name, code: o.code })),
     perDay: data.perDay,
     segments: (data.segments ?? []).map((o) => ({

--- a/src/graphql/ad-set.generated.tsx
+++ b/src/graphql/ad-set.generated.tsx
@@ -9,24 +9,19 @@ export type AdSetFragment = {
   price?: string | null;
   createdAt: any;
   billingType?: string | null;
-  name?: string | null;
+  name: string;
   totalMax: number;
   perDay: number;
   state: string;
-  execution?: string | null;
-  keywords?: Array<string> | null;
-  keywordSimilarity?: number | null;
-  negativeKeywords?: Array<string> | null;
-  bannedKeywords?: Array<string> | null;
-  segments?: Array<{ code: string; name: string }> | null;
-  oses?: Array<{ code: string; name: string }> | null;
-  conversions?: Array<{
+  segments: Array<{ code: string; name: string }>;
+  oses: Array<{ code: string; name: string }>;
+  conversions: Array<{
     id: string;
     type: string;
     urlPattern: string;
     observationWindow: number;
-  }> | null;
-  ads?: Array<{
+  }>;
+  ads: Array<{
     id: string;
     state: string;
     price: string;
@@ -73,7 +68,7 @@ export type AdSetFragment = {
         ctaText: string;
       } | null;
     };
-  }> | null;
+  }>;
 };
 
 export type AdFragment = {
@@ -135,24 +130,19 @@ export type CreateAdSetMutation = {
     price?: string | null;
     createdAt: any;
     billingType?: string | null;
-    name?: string | null;
+    name: string;
     totalMax: number;
     perDay: number;
     state: string;
-    execution?: string | null;
-    keywords?: Array<string> | null;
-    keywordSimilarity?: number | null;
-    negativeKeywords?: Array<string> | null;
-    bannedKeywords?: Array<string> | null;
-    segments?: Array<{ code: string; name: string }> | null;
-    oses?: Array<{ code: string; name: string }> | null;
-    conversions?: Array<{
+    segments: Array<{ code: string; name: string }>;
+    oses: Array<{ code: string; name: string }>;
+    conversions: Array<{
       id: string;
       type: string;
       urlPattern: string;
       observationWindow: number;
-    }> | null;
-    ads?: Array<{
+    }>;
+    ads: Array<{
       id: string;
       state: string;
       price: string;
@@ -203,7 +193,7 @@ export type CreateAdSetMutation = {
           ctaText: string;
         } | null;
       };
-    }> | null;
+    }>;
   };
 };
 
@@ -217,24 +207,19 @@ export type UpdateAdSetMutation = {
     price?: string | null;
     createdAt: any;
     billingType?: string | null;
-    name?: string | null;
+    name: string;
     totalMax: number;
     perDay: number;
     state: string;
-    execution?: string | null;
-    keywords?: Array<string> | null;
-    keywordSimilarity?: number | null;
-    negativeKeywords?: Array<string> | null;
-    bannedKeywords?: Array<string> | null;
-    segments?: Array<{ code: string; name: string }> | null;
-    oses?: Array<{ code: string; name: string }> | null;
-    conversions?: Array<{
+    segments: Array<{ code: string; name: string }>;
+    oses: Array<{ code: string; name: string }>;
+    conversions: Array<{
       id: string;
       type: string;
       urlPattern: string;
       observationWindow: number;
-    }> | null;
-    ads?: Array<{
+    }>;
+    ads: Array<{
       id: string;
       state: string;
       price: string;
@@ -285,7 +270,7 @@ export type UpdateAdSetMutation = {
           ctaText: string;
         } | null;
       };
-    }> | null;
+    }>;
   };
 };
 
@@ -311,11 +296,6 @@ export const AdSetFragmentDoc = gql`
     totalMax
     perDay
     state
-    execution
-    keywords
-    keywordSimilarity
-    negativeKeywords
-    bannedKeywords
     segments {
       code
       name

--- a/src/graphql/ad-set.graphql
+++ b/src/graphql/ad-set.graphql
@@ -7,11 +7,6 @@ fragment AdSet on AdSet {
   totalMax
   perDay
   state
-  execution
-  keywords
-  keywordSimilarity
-  negativeKeywords
-  bannedKeywords
   segments {
     code
     name

--- a/src/graphql/advertiser.generated.tsx
+++ b/src/graphql/advertiser.generated.tsx
@@ -68,7 +68,7 @@ export type AdvertiserCampaignsFragment = {
     passThroughRate: number;
     pacingOverride: boolean;
     pacingStrategy: Types.CampaignPacingStrategies;
-    externalId: string;
+    externalId?: string | null;
     currency: string;
     budget: number;
     paymentType: Types.PaymentType;
@@ -104,7 +104,7 @@ export type AdvertiserCampaignsQuery = {
       passThroughRate: number;
       pacingOverride: boolean;
       pacingStrategy: Types.CampaignPacingStrategies;
-      externalId: string;
+      externalId?: string | null;
       currency: string;
       budget: number;
       paymentType: Types.PaymentType;

--- a/src/graphql/analytics-overview.generated.tsx
+++ b/src/graphql/analytics-overview.generated.tsx
@@ -38,9 +38,9 @@ export type CampaignWithEngagementsFragment = {
   pacingIndex?: number | null;
   format: Types.CampaignFormat;
   adSets: Array<{
-    conversions?: Array<{ type: string; extractExternalId: boolean }> | null;
+    conversions: Array<{ type: string; extractExternalId: boolean }>;
   }>;
-  engagements?: Array<{
+  engagements: Array<{
     creativeinstanceid: string;
     createdat: any;
     type: string;
@@ -59,7 +59,7 @@ export type CampaignWithEngagementsFragment = {
     linux: number;
     macos: number;
     windows: number;
-  }> | null;
+  }>;
 };
 
 export type AnalyticOverviewQueryVariables = Types.Exact<{
@@ -81,9 +81,9 @@ export type AnalyticOverviewQuery = {
     pacingIndex?: number | null;
     format: Types.CampaignFormat;
     adSets: Array<{
-      conversions?: Array<{ type: string; extractExternalId: boolean }> | null;
+      conversions: Array<{ type: string; extractExternalId: boolean }>;
     }>;
-    engagements?: Array<{
+    engagements: Array<{
       creativeinstanceid: string;
       createdat: any;
       type: string;
@@ -102,7 +102,7 @@ export type AnalyticOverviewQuery = {
       linux: number;
       macos: number;
       windows: number;
-    }> | null;
+    }>;
   } | null;
 };
 

--- a/src/graphql/campaign.generated.tsx
+++ b/src/graphql/campaign.generated.tsx
@@ -13,7 +13,7 @@ export type CampaignFragment = {
   passThroughRate: number;
   pacingOverride: boolean;
   pacingStrategy: Types.CampaignPacingStrategies;
-  externalId: string;
+  externalId?: string | null;
   currency: string;
   budget: number;
   dailyBudget: number;
@@ -27,36 +27,27 @@ export type CampaignFragment = {
   paymentType: Types.PaymentType;
   dayProportion?: number | null;
   stripePaymentId?: string | null;
-  hasPaymentIntent?: boolean | null;
-  dayPartings?: Array<{
-    dow: string;
-    startMinute: number;
-    endMinute: number;
-  }> | null;
-  geoTargets?: Array<{ code: string; name: string }> | null;
+  hasPaymentIntent: boolean;
+  dayPartings: Array<{ dow: string; startMinute: number; endMinute: number }>;
+  geoTargets: Array<{ code: string; name: string }>;
   adSets: Array<{
     id: string;
     price?: string | null;
     createdAt: any;
     billingType?: string | null;
-    name?: string | null;
+    name: string;
     totalMax: number;
     perDay: number;
     state: string;
-    execution?: string | null;
-    keywords?: Array<string> | null;
-    keywordSimilarity?: number | null;
-    negativeKeywords?: Array<string> | null;
-    bannedKeywords?: Array<string> | null;
-    segments?: Array<{ code: string; name: string }> | null;
-    oses?: Array<{ code: string; name: string }> | null;
-    conversions?: Array<{
+    segments: Array<{ code: string; name: string }>;
+    oses: Array<{ code: string; name: string }>;
+    conversions: Array<{
       id: string;
       type: string;
       urlPattern: string;
       observationWindow: number;
-    }> | null;
-    ads?: Array<{
+    }>;
+    ads: Array<{
       id: string;
       state: string;
       price: string;
@@ -107,7 +98,7 @@ export type CampaignFragment = {
           ctaText: string;
         } | null;
       };
-    }> | null;
+    }>;
   }>;
   advertiser: { id: string };
 };
@@ -121,7 +112,7 @@ export type CampaignSummaryFragment = {
   passThroughRate: number;
   pacingOverride: boolean;
   pacingStrategy: Types.CampaignPacingStrategies;
-  externalId: string;
+  externalId?: string | null;
   currency: string;
   budget: number;
   paymentType: Types.PaymentType;
@@ -151,24 +142,19 @@ export type CampaignAdsFragment = {
     price?: string | null;
     createdAt: any;
     billingType?: string | null;
-    name?: string | null;
+    name: string;
     totalMax: number;
     perDay: number;
     state: string;
-    execution?: string | null;
-    keywords?: Array<string> | null;
-    keywordSimilarity?: number | null;
-    negativeKeywords?: Array<string> | null;
-    bannedKeywords?: Array<string> | null;
-    segments?: Array<{ code: string; name: string }> | null;
-    oses?: Array<{ code: string; name: string }> | null;
-    conversions?: Array<{
+    segments: Array<{ code: string; name: string }>;
+    oses: Array<{ code: string; name: string }>;
+    conversions: Array<{
       id: string;
       type: string;
       urlPattern: string;
       observationWindow: number;
-    }> | null;
-    ads?: Array<{
+    }>;
+    ads: Array<{
       id: string;
       state: string;
       price: string;
@@ -219,7 +205,7 @@ export type CampaignAdsFragment = {
           ctaText: string;
         } | null;
       };
-    }> | null;
+    }>;
   }>;
 };
 
@@ -237,7 +223,7 @@ export type LoadCampaignQuery = {
     passThroughRate: number;
     pacingOverride: boolean;
     pacingStrategy: Types.CampaignPacingStrategies;
-    externalId: string;
+    externalId?: string | null;
     currency: string;
     budget: number;
     dailyBudget: number;
@@ -251,36 +237,27 @@ export type LoadCampaignQuery = {
     paymentType: Types.PaymentType;
     dayProportion?: number | null;
     stripePaymentId?: string | null;
-    hasPaymentIntent?: boolean | null;
-    dayPartings?: Array<{
-      dow: string;
-      startMinute: number;
-      endMinute: number;
-    }> | null;
-    geoTargets?: Array<{ code: string; name: string }> | null;
+    hasPaymentIntent: boolean;
+    dayPartings: Array<{ dow: string; startMinute: number; endMinute: number }>;
+    geoTargets: Array<{ code: string; name: string }>;
     adSets: Array<{
       id: string;
       price?: string | null;
       createdAt: any;
       billingType?: string | null;
-      name?: string | null;
+      name: string;
       totalMax: number;
       perDay: number;
       state: string;
-      execution?: string | null;
-      keywords?: Array<string> | null;
-      keywordSimilarity?: number | null;
-      negativeKeywords?: Array<string> | null;
-      bannedKeywords?: Array<string> | null;
-      segments?: Array<{ code: string; name: string }> | null;
-      oses?: Array<{ code: string; name: string }> | null;
-      conversions?: Array<{
+      segments: Array<{ code: string; name: string }>;
+      oses: Array<{ code: string; name: string }>;
+      conversions: Array<{
         id: string;
         type: string;
         urlPattern: string;
         observationWindow: number;
-      }> | null;
-      ads?: Array<{
+      }>;
+      ads: Array<{
         id: string;
         state: string;
         price: string;
@@ -331,7 +308,7 @@ export type LoadCampaignQuery = {
             ctaText: string;
           } | null;
         };
-      }> | null;
+      }>;
     }>;
     advertiser: { id: string };
   } | null;
@@ -357,24 +334,19 @@ export type LoadCampaignAdsQuery = {
       price?: string | null;
       createdAt: any;
       billingType?: string | null;
-      name?: string | null;
+      name: string;
       totalMax: number;
       perDay: number;
       state: string;
-      execution?: string | null;
-      keywords?: Array<string> | null;
-      keywordSimilarity?: number | null;
-      negativeKeywords?: Array<string> | null;
-      bannedKeywords?: Array<string> | null;
-      segments?: Array<{ code: string; name: string }> | null;
-      oses?: Array<{ code: string; name: string }> | null;
-      conversions?: Array<{
+      segments: Array<{ code: string; name: string }>;
+      oses: Array<{ code: string; name: string }>;
+      conversions: Array<{
         id: string;
         type: string;
         urlPattern: string;
         observationWindow: number;
-      }> | null;
-      ads?: Array<{
+      }>;
+      ads: Array<{
         id: string;
         state: string;
         price: string;
@@ -425,7 +397,7 @@ export type LoadCampaignAdsQuery = {
             ctaText: string;
           } | null;
         };
-      }> | null;
+      }>;
     }>;
   } | null;
 };

--- a/src/user/library/index.test.ts
+++ b/src/user/library/index.test.ts
@@ -41,6 +41,8 @@ const BASE_CPM_CAMPAIGN_FRAGMENT: Readonly<CampaignFragment> = {
   type: "paid",
   format: CampaignFormat.PushNotification,
   paymentType: PaymentType.Stripe,
+  dayPartings: [],
+  hasPaymentIntent: false,
   geoTargets: [
     {
       code: "US",
@@ -57,7 +59,6 @@ const BASE_CPM_CAMPAIGN_FRAGMENT: Readonly<CampaignFragment> = {
       totalMax: 10,
       perDay: 1,
       state: "active",
-      execution: "per_click",
       segments: [
         {
           code: "elchqV0qNh",


### PR DESCRIPTION
- `execution` is long obsolete
- search adset properties are not (yet) required