### PR TITLE
fix: use Ads verbiage over creative verbiage

### DIFF
--- a/src/components/Creatives/CreativeList.tsx
+++ b/src/components/Creatives/CreativeList.tsx
@@ -87,7 +87,7 @@ export function CreativeList() {
         />
       )}
       <CardContainer
-        header="Creatives"
+        header="Ads"
         sx={{
           flexGrow: 1,
           overflowX: "auto",

--- a/src/components/Creatives/hooks/useSubmitCreative.tsx
+++ b/src/components/Creatives/hooks/useSubmitCreative.tsx
@@ -17,7 +17,7 @@ export function useSubmitCreative(props: { id: string }) {
   const refetchQueries = [
     refetchAdvertiserCreativesQuery({ advertiserId: advertiser.id }),
   ];
-  const onCompleted = () => history.replace("/user/main/creatives");
+  const onCompleted = () => history.replace("/user/main/ads");
 
   const [createCreative, { error: createError, loading: createLoading }] =
     useCreateCreativeMutation({

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -57,8 +57,8 @@ export default function MiniSideBar({ children }: PropsWithChildren) {
       disabled: !advertiser.selfServiceManageCampaign,
     },
     {
-      label: "Creatives",
-      href: "/user/main/creatives",
+      label: "Ads",
+      href: "/user/main/ads",
       icon: (
         <LightbulbOutlinedIcon
           fontSize="large"

--- a/src/components/Navigation/Navbar.tsx
+++ b/src/components/Navigation/Navbar.tsx
@@ -24,7 +24,7 @@ export function Navbar() {
       component: <UploadImage />,
     },
     {
-      route: "user/main/creatives",
+      route: "user/main/ads",
       component: <NewCreativeButton />,
     },
   ];

--- a/src/user/User.tsx
+++ b/src/user/User.tsx
@@ -118,6 +118,8 @@ export function User() {
                 authedComponent={CreativeList}
               />
 
+              <Redirect from="/user/main/creatives" to="/user/main/ads" exact />
+
               {/* default */}
               <Redirect to="/user/main/campaign" />
             </Switch>

--- a/src/user/User.tsx
+++ b/src/user/User.tsx
@@ -114,7 +114,7 @@ export function User() {
               />
 
               <ProtectedRoute
-                path="/user/main/creatives"
+                path="/user/main/ads"
                 authedComponent={CreativeList}
               />
 

--- a/src/user/ads/InlineContentAd.tsx
+++ b/src/user/ads/InlineContentAd.tsx
@@ -26,7 +26,7 @@ export function InlineContentAd(props: {
 
   return (
     <Box display="flex" flexDirection="column" gap={2}>
-      <CardContainer header="News display creative" sx={{ flexGrow: 1 }}>
+      <CardContainer header="News Display Ad" sx={{ flexGrow: 1 }}>
         <FormikTextField name={withName("name")} label="Name" />
 
         <FormikTextField

--- a/src/user/ads/NotificationAd.tsx
+++ b/src/user/ads/NotificationAd.tsx
@@ -19,7 +19,7 @@ export function NotificationAd(props: {
   }, []);
 
   return (
-    <CardContainer header="Notification creative">
+    <CardContainer header="Notification Ad">
       <FormikTextField name={withName("name")} label="Name" />
 
       <Stack direction="row" alignItems="center" spacing={1}>


### PR DESCRIPTION
Rename external facing "Creative" verbiage to "Ads"