### PR TITLE
fix: make sure ads are relevant to campaign format

### DIFF
--- a/src/components/Creatives/CreateCreativeButton.tsx
+++ b/src/components/Creatives/CreateCreativeButton.tsx
@@ -61,7 +61,7 @@ export function CreateCreativeButton() {
       }
       loading={loading}
     >
-      Add
+      Save Ad
     </LoadingButton>
   );
 }

--- a/src/user/hooks/useAdvertiserCreatives.ts
+++ b/src/user/hooks/useAdvertiserCreatives.ts
@@ -1,11 +1,12 @@
 import { useFormikContext } from "formik";
 import { CampaignForm, Creative } from "user/views/adsManager/types";
 import _ from "lodash";
+import { isCreativeTypeApplicableToCampaignFormat } from "user/library";
 
 export function useAdvertiserCreatives() {
   const { values } = useFormikContext<CampaignForm>();
-  const inAdSet: Creative[] = _.flatMap(values.adSets, "creatives").map(
-    (c: Creative) => ({
+  const inAdSet: Creative[] = _.flatMap(values.adSets, "creatives")
+    .map((c: Creative) => ({
       type: c.type,
       payloadNotification: c.payloadNotification,
       payloadInlineContent: c.payloadInlineContent,
@@ -15,8 +16,10 @@ export function useAdvertiserCreatives() {
       state: c.state,
       createdAt: c.createdAt,
       included: false,
-    }),
-  );
+    }))
+    .filter((c) =>
+      isCreativeTypeApplicableToCampaignFormat(c.type, values.format),
+    );
 
   return { creatives: _.uniqBy(inAdSet, "id") };
 }

--- a/src/user/library/index.test.ts
+++ b/src/user/library/index.test.ts
@@ -201,7 +201,7 @@ describe("new form tests", () => {
     included: true,
     name: "Test",
     state: "draft",
-    type: { code: "test" },
+    type: { code: "notification_all_v1" },
   };
 
   const creative2: Creative = {

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -53,7 +53,11 @@ export function transformNewForm(
       ...transformAdSet(a, form),
       conversions: transformConversion(a.conversions),
       ads: a.creatives
-        .filter((c) => c.included)
+        .filter(
+          (c) =>
+            c.included &&
+            isCreativeTypeApplicableToCampaignFormat(c.type, form.format),
+        )
         .map((ad) => ({ creativeId: ad.id })),
     })),
     paymentType: form.paymentType,

--- a/src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx
+++ b/src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx
@@ -3,6 +3,7 @@ import { Typography } from "@mui/material";
 import { CampaignForm } from "user/views/adsManager/types";
 import { useFormikContext } from "formik";
 import { CreativeSelect } from "components/Creatives/CreativeSelect";
+import { isCreativeTypeApplicableToCampaignFormat } from "user/library";
 
 interface Props {
   index: number;
@@ -11,13 +12,16 @@ interface Props {
 export function AdSetAds({ index }: Props) {
   const { values } = useFormikContext<CampaignForm>();
 
+  const adsByFormat = values.adSets[index].creatives.filter((c) =>
+    isCreativeTypeApplicableToCampaignFormat(c.type, values.format),
+  );
   return (
     <CardContainer header="Ads">
       <Typography variant="body2" sx={{ mb: 3 }}>
         Select the Ads you would like to include in this ad set.
       </Typography>
 
-      <CreativeSelect index={index} options={values.adSets[index].creatives} />
+      <CreativeSelect index={index} options={adsByFormat} />
     </CardContainer>
   );
 }


### PR DESCRIPTION
Fixes when switching ad types, the ads from different types being part of the campaign

---


https://github.com/brave/ads-ui/assets/48930920/d735f801-9dd4-4b6d-a81c-31183952fd79

