### PR TITLE
feat: add support for multiple billing types

### DIFF
--- a/src/form/FormikHelpers.tsx
+++ b/src/form/FormikHelpers.tsx
@@ -29,6 +29,7 @@ type FormikTextFieldProps = TextFieldProps & {
   type?: HTMLInputTypeAttribute;
   disabled?: boolean;
   useTopLabel?: boolean;
+  growInput?: boolean;
 };
 
 export const FormikTextField = (props: FormikTextFieldProps) => {
@@ -45,7 +46,7 @@ export const FormikTextField = (props: FormikTextFieldProps) => {
 
   const extraOmit = props.useTopLabel ? ["label"] : [];
   return (
-    <Box flexGrow={1}>
+    <Box flexGrow={props.growInput !== false ? 1 : 0}>
       {props.useTopLabel && (
         <FormLabel sx={{ color: "text.primary" }}> {props.label} </FormLabel>
       )}

--- a/src/form/FormikHelpers.tsx
+++ b/src/form/FormikHelpers.tsx
@@ -126,7 +126,7 @@ export const FormikRadioGroup = (
 
 interface FormikRadioControlProps {
   name: string;
-  options: Array<{ label: string; value: string | number }>;
+  options: Array<{ label: string; value: string | number | object }>;
   label?: string;
   helperText?: ReactNode;
   disabled?: boolean;
@@ -144,9 +144,9 @@ export const FormikRadioControl = (props: FormikRadioControlProps) => {
         {props.label}
       </FormLabel>
       <FormikRadioGroup row name={props.name} onChange={props.onChange}>
-        {props.options.map((opt) => (
+        {props.options.map((opt, idx) => (
           <FormControlLabel
-            key={opt.value}
+            key={`${props.name}_radio_${idx}`}
             value={opt.value}
             label={opt.label}
             control={<Radio />}

--- a/src/form/FormikHelpers.tsx
+++ b/src/form/FormikHelpers.tsx
@@ -126,7 +126,7 @@ export const FormikRadioGroup = (
 
 interface FormikRadioControlProps {
   name: string;
-  options: Array<{ label: string; value: string | number | object }>;
+  options: Array<{ label: string; value: string | number }>;
   label?: string;
   helperText?: ReactNode;
   disabled?: boolean;

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -27,6 +27,8 @@ export type Scalars = {
   Float: { input: number; output: number };
   /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
   DateTime: { input: any; output: any };
+  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
+  JSONObject: { input: any; output: any };
   /** The `Numeric` datatype represents a fixed-precision number, which does not suffer from the rounding errors of a javascript floating point number. It's always returned as a string, but for input types either a string or number can be used, though strings are preferred to avoid risk of inaccuracy. */
   Numeric: { input: string; output: string };
 };
@@ -58,7 +60,7 @@ export type ApproveCampaignInput = {
 export enum BillingType {
   Cpc = "CPC",
   Cpm = "CPM",
-  Cpv = "CPV",
+  Cpsv = "CPSV",
 }
 
 export type CampaignFilter = {
@@ -143,13 +145,12 @@ export type CreateAdSetInput = {
   bannedKeywords?: InputMaybe<Array<Scalars["String"]["input"]>>;
   billingType: Scalars["String"]["input"];
   campaignId?: InputMaybe<Scalars["String"]["input"]>;
-  channels?: InputMaybe<Array<CreateChannelInput>>;
   conversions?: InputMaybe<Array<CreateConversionInput>>;
-  execution?: InputMaybe<Scalars["String"]["input"]>;
   keywordSimilarity?: InputMaybe<Scalars["Float"]["input"]>;
   keywords?: InputMaybe<Array<Scalars["String"]["input"]>>;
   name?: InputMaybe<Scalars["String"]["input"]>;
   negativeKeywords?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  negativeTriggerUrls?: InputMaybe<Array<Scalars["String"]["input"]>>;
   oses?: InputMaybe<Array<CreateOsInput>>;
   perDay: Scalars["Float"]["input"];
   /** The price in the owning campaign's currency for each single confirmation of the priceType specified. Note therefore that the caller is responsible for dividing cost-per-mille by 1000. */
@@ -159,6 +160,7 @@ export type CreateAdSetInput = {
   state?: InputMaybe<Scalars["String"]["input"]>;
   targetingTerms?: InputMaybe<Array<Scalars["String"]["input"]>>;
   totalMax: Scalars["Float"]["input"];
+  triggerUrls?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };
 
 export type CreateAddressInput = {
@@ -215,10 +217,6 @@ export type CreateCampaignInput = {
   state: Scalars["String"]["input"];
   type: Scalars["String"]["input"];
   userId?: InputMaybe<Scalars["String"]["input"]>;
-};
-
-export type CreateChannelInput = {
-  channelId: Scalars["String"]["input"];
 };
 
 export type CreateCommentInput = {
@@ -407,6 +405,10 @@ export type SearchHomepagePayloadInput = {
 
 export type SearchPayloadInput = {
   body: Scalars["String"]["input"];
+  /** ad-hoc parameters passed to search */
+  meta?: InputMaybe<Scalars["JSONObject"]["input"]>;
+  /** optionally, how this creative should be rendered with the SERP */
+  style?: InputMaybe<Scalars["String"]["input"]>;
   targetUrl: Scalars["String"]["input"];
   title: Scalars["String"]["input"];
 };
@@ -424,14 +426,13 @@ export type UpdateAdSetInput = {
   bannedKeywords?: InputMaybe<Array<Scalars["String"]["input"]>>;
   billingType?: InputMaybe<Scalars["String"]["input"]>;
   campaignId?: InputMaybe<Scalars["String"]["input"]>;
-  channels?: InputMaybe<Array<CreateChannelInput>>;
   conversions?: InputMaybe<Array<UpdateConversionsInput>>;
-  execution?: InputMaybe<Scalars["String"]["input"]>;
   id?: InputMaybe<Scalars["String"]["input"]>;
   keywordSimilarity?: InputMaybe<Scalars["Float"]["input"]>;
   keywords?: InputMaybe<Array<Scalars["String"]["input"]>>;
   name?: InputMaybe<Scalars["String"]["input"]>;
   negativeKeywords?: InputMaybe<Array<Scalars["String"]["input"]>>;
+  negativeTriggerUrls?: InputMaybe<Array<Scalars["String"]["input"]>>;
   optimized?: InputMaybe<Scalars["Boolean"]["input"]>;
   oses?: InputMaybe<Array<UpdateOSesInput>>;
   perDay?: InputMaybe<Scalars["Float"]["input"]>;
@@ -442,6 +443,7 @@ export type UpdateAdSetInput = {
   state?: InputMaybe<Scalars["String"]["input"]>;
   targetingTerms?: InputMaybe<Array<Scalars["String"]["input"]>>;
   totalMax?: InputMaybe<Scalars["Float"]["input"]>;
+  triggerUrls?: InputMaybe<Array<Scalars["String"]["input"]>>;
 };
 
 export type UpdateAddressInput = {

--- a/src/user/hooks/useAdvertiserWithPrices.tsx
+++ b/src/user/hooks/useAdvertiserWithPrices.tsx
@@ -37,6 +37,7 @@ export function useAdvertiserWithPrices(params: Params = {}) {
         return;
       }
 
+      // TODO: no documentation externally on what CPSV means, want that before I remove this
       const mapped: AdvertiserPrice[] = prices
         .filter((p) => p.billingType !== BillingType.Cpsv)
         .map((p) => ({

--- a/src/user/hooks/useAdvertiserWithPrices.tsx
+++ b/src/user/hooks/useAdvertiserWithPrices.tsx
@@ -6,11 +6,21 @@ import {
 import { useState } from "react";
 import { IAdvertiser } from "auth/context/auth.interface";
 import _ from "lodash";
+import { BillingType } from "graphql/types";
+import { Billing } from "user/views/adsManager/types";
 
-export type AdvertiserWithPrices = IAdvertiser & {
-  prices: AdvertiserPriceFragment[];
+export type AdvertiserPrice = Omit<AdvertiserPriceFragment, "billingType"> & {
+  billingType: Billing;
 };
-export function useAdvertiserWithPrices() {
+export type AdvertiserWithPrices = IAdvertiser & {
+  prices: AdvertiserPrice[];
+};
+
+interface Params {
+  onComplete?: (data: AdvertiserWithPrices) => void;
+}
+
+export function useAdvertiserWithPrices(params: Params = {}) {
   const { advertiser } = useAdvertiser();
   const [data, setData] = useState<AdvertiserWithPrices>({
     ...advertiser,
@@ -27,10 +37,19 @@ export function useAdvertiserWithPrices() {
         return;
       }
 
-      setData({
-        ...advertiser,
-        prices,
-      });
+      const mapped: AdvertiserPrice[] = prices
+        .filter((p) => p.billingType !== BillingType.Cpsv)
+        .map((p) => ({
+          ...p,
+          billingType: p.billingType.toLowerCase() as Billing,
+        }));
+
+      const res = { ...advertiser, prices: mapped };
+      setData(res);
+
+      if (params.onComplete) {
+        params.onComplete(res);
+      }
     },
     onError(error) {
       setError(error.message);

--- a/src/user/library/index.test.ts
+++ b/src/user/library/index.test.ts
@@ -182,9 +182,9 @@ describe("pricing logic (write)", () => {
     expect(result).toEqual("9");
   });
 
-  it("should not convert CPV to per-impression values when populating a CPV creative", () => {
+  it("should not convert CPSV to per-impression values when populating a CPSV creative", () => {
     const result = transformPrice({
-      billingType: "cpv",
+      billingType: "cpsv",
       price: "9",
     });
 

--- a/src/user/views/adsManager/types/index.ts
+++ b/src/user/views/adsManager/types/index.ts
@@ -3,7 +3,7 @@ import { defaultEndDate, defaultStartDate } from "form/DateFieldHelpers";
 import { MIN_PER_CAMPAIGN } from "validation/CampaignSchema";
 import { AdvertiserWithPrices } from "user/hooks/useAdvertiserWithPrices";
 
-export type Billing = "cpm" | "cpc" | "cpv";
+export type Billing = "cpm" | "cpc" | "cpsv";
 
 export type CampaignForm = {
   id?: string;

--- a/src/user/views/adsManager/types/index.ts
+++ b/src/user/views/adsManager/types/index.ts
@@ -29,6 +29,11 @@ export type CampaignForm = {
   paymentType: PaymentType;
 };
 
+export type BillingModel = {
+  type: Billing;
+  price: string;
+};
+
 export type GeoTarget = {
   code: string;
   name: string;
@@ -111,11 +116,6 @@ export const initialAdSet: AdSetForm = {
 export const initialCampaign = (
   advertiser: AdvertiserWithPrices,
 ): CampaignForm => {
-  const format = CampaignFormat.PushNotification;
-  const billingType = "cpm";
-  const price = advertiser.prices.find(
-    (p) => p.billingType === billingType.toUpperCase() && p.format === format,
-  );
   return {
     isCreating: false,
     advertiserId: advertiser.id,
@@ -126,15 +126,15 @@ export const initialCampaign = (
     dailyBudget: MIN_PER_CAMPAIGN,
     geoTargets: [],
     newCreative: initialCreative,
-    billingType,
+    billingType: advertiser.prices[0].billingType,
+    price: advertiser.prices[0].billingModelPrice,
     currency: "USD",
-    price: price?.billingModelPrice ?? "6",
     adSets: [
       {
         ...initialAdSet,
       },
     ],
-    format,
+    format: advertiser.prices[0].format,
     name: "",
     state: "draft",
     type: "paid",

--- a/src/user/views/adsManager/types/index.ts
+++ b/src/user/views/adsManager/types/index.ts
@@ -29,11 +29,6 @@ export type CampaignForm = {
   paymentType: PaymentType;
 };
 
-export type BillingModel = {
-  type: Billing;
-  price: string;
-};
-
 export type GeoTarget = {
   code: string;
   name: string;

--- a/src/user/views/adsManager/views/advanced/components/campaign/CampaignSettings.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/CampaignSettings.tsx
@@ -4,9 +4,9 @@ import { CampaignDateRange } from "components/Campaigns/CampaignDateRange";
 import { LocationField } from "user/views/adsManager/views/advanced/components/campaign/fields/LocationField";
 import { Typography } from "@mui/material";
 import { FormatField } from "user/views/adsManager/views/advanced/components/campaign/fields/FormatField";
-import { AdvertiserPriceFragment } from "graphql/advertiser.generated";
+import { AdvertiserPrice } from "user/hooks/useAdvertiserWithPrices";
 
-export function CampaignSettings(props: { prices: AdvertiserPriceFragment[] }) {
+export function CampaignSettings(props: { prices: AdvertiserPrice[] }) {
   const { isDraft } = useIsEdit();
 
   return (

--- a/src/user/views/adsManager/views/advanced/components/campaign/components/BillingModelSelect.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/components/BillingModelSelect.tsx
@@ -27,9 +27,9 @@ export function BillingModelSelect(props: { prices: AdvertiserPrice[] }) {
               key={`billing_model_${p.format}_${p.billingType}`}
               disabled={isEdit}
               selected={bMeta.value === p.billingType}
-              onClick={() => {
-                price.setValue(p.billingModelPrice);
-                billing.setValue(p.billingType);
+              onClick={async () => {
+                await price.setValue(p.billingModelPrice, true);
+                await billing.setValue(p.billingType, true);
               }}
               sx={{
                 p: 2,

--- a/src/user/views/adsManager/views/advanced/components/campaign/components/BillingModelSelect.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/components/BillingModelSelect.tsx
@@ -1,0 +1,48 @@
+import { List, ListItemButton, Stack, Typography } from "@mui/material";
+import { renderMonetaryAmount } from "components/Datagrid/renderers";
+import { useIsEdit } from "form/FormikHelpers";
+import { useField } from "formik";
+import { CampaignFormat } from "graphql/types";
+import { AdvertiserPrice } from "user/hooks/useAdvertiserWithPrices";
+import { Billing } from "user/views/adsManager/types";
+import { uiLabelsForCampaignFormat } from "util/campaign";
+import { uiLabelsForBillingType } from "util/billingType";
+
+export function BillingModelSelect(props: { prices: AdvertiserPrice[] }) {
+  const { isEdit } = useIsEdit();
+  const [, , price] = useField<string>("price");
+  const [, format] = useField<CampaignFormat>("format");
+  const [, bMeta, billing] = useField<Billing>("billingType");
+
+  return (
+    <Stack maxWidth={500}>
+      <Typography variant="body2">
+        {uiLabelsForCampaignFormat(format.value)} billing configuration
+      </Typography>
+      <List sx={{ display: "flex", flexDirection: "row", gap: "20px" }}>
+        {props.prices
+          .filter((p) => p.format === format.value)
+          .map((p) => (
+            <ListItemButton
+              key={`billing_model_${p.format}_${p.billingType}`}
+              disabled={isEdit}
+              selected={bMeta.value === p.billingType}
+              onClick={() => {
+                price.setValue(p.billingModelPrice);
+                billing.setValue(p.billingType);
+              }}
+              sx={{
+                p: 2,
+                borderRadius: "16px",
+                border: "1px solid #7c91ff",
+              }}
+            >
+              {`${renderMonetaryAmount(Number(p.billingModelPrice), "USD")} ${
+                uiLabelsForBillingType(p.billingType).longLabel
+              }`}
+            </ListItemButton>
+          ))}
+      </List>
+    </Stack>
+  );
+}

--- a/src/user/views/adsManager/views/advanced/components/campaign/components/CustomPriceSelect.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/components/CustomPriceSelect.tsx
@@ -1,0 +1,43 @@
+import {
+  FormikRadioControl,
+  FormikTextField,
+  useIsEdit,
+} from "form/FormikHelpers";
+import { useField } from "formik";
+import { CampaignFormat } from "graphql/types";
+import { InputAdornment, Stack } from "@mui/material";
+import { uiLabelsForBillingType } from "util/billingType";
+
+export function CustomPriceSelect() {
+  const { isDraft } = useIsEdit();
+  const [, format] = useField<CampaignFormat>("format");
+
+  return (
+    <Stack direction="column" spacing={2} alignItems="flex-start">
+      <FormikRadioControl
+        name="billingType"
+        options={[
+          {
+            value: "cpm",
+            label: uiLabelsForBillingType("cpm").longLabel,
+          },
+          {
+            value: "cpc",
+            label: uiLabelsForBillingType("cpc").longLabel,
+          },
+        ]}
+        disabled={!isDraft || format.value === CampaignFormat.NewsDisplayAd}
+      />
+      <FormikTextField
+        fullWidth={false}
+        name="price"
+        label="Price"
+        type="number"
+        InputProps={{
+          startAdornment: <InputAdornment position="start">$</InputAdornment>,
+        }}
+        disabled={!isDraft}
+      />
+    </Stack>
+  );
+}

--- a/src/user/views/adsManager/views/advanced/components/campaign/components/CustomPriceSelect.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/components/CustomPriceSelect.tsx
@@ -13,8 +13,21 @@ export function CustomPriceSelect() {
   const [, format] = useField<CampaignFormat>("format");
 
   return (
-    <Stack direction="column" spacing={2} alignItems="flex-start">
+    <Stack direction="row" spacing={2} alignItems="center">
+      <FormikTextField
+        fullWidth={false}
+        name="price"
+        label="Price"
+        type="number"
+        growInput={false}
+        InputProps={{
+          startAdornment: <InputAdornment position="start">$</InputAdornment>,
+        }}
+        disabled={!isDraft}
+        margin="dense"
+      />
       <FormikRadioControl
+        label="Billing Type"
         name="billingType"
         options={[
           {
@@ -27,16 +40,6 @@ export function CustomPriceSelect() {
           },
         ]}
         disabled={!isDraft || format.value === CampaignFormat.NewsDisplayAd}
-      />
-      <FormikTextField
-        fullWidth={false}
-        name="price"
-        label="Price"
-        type="number"
-        InputProps={{
-          startAdornment: <InputAdornment position="start">$</InputAdornment>,
-        }}
-        disabled={!isDraft}
       />
     </Stack>
   );

--- a/src/user/views/adsManager/views/advanced/components/campaign/fields/BudgetField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/fields/BudgetField.tsx
@@ -1,25 +1,19 @@
 import { InputAdornment, Stack, Typography } from "@mui/material";
-import {
-  FormikRadioControl,
-  FormikTextField,
-  useIsEdit,
-} from "form/FormikHelpers";
+import { FormikTextField, useIsEdit } from "form/FormikHelpers";
 import { useEffect, useState } from "react";
 import { useField, useFormikContext } from "formik";
 import { CampaignForm } from "../../../../../types";
 import { differenceInHours } from "date-fns";
 import { MIN_PER_CAMPAIGN, MIN_PER_DAY } from "validation/CampaignSchema";
-import _ from "lodash";
 import { CardContainer } from "components/Card/CardContainer";
-import { uiLabelsForBillingType } from "util/billingType";
-import { uiTextForCampaignFormat } from "user/library";
-import { CampaignFormat } from "graphql/types";
 import { useAdvertiserWithPrices } from "user/hooks/useAdvertiserWithPrices";
+import { BillingModelSelect } from "../components/BillingModelSelect";
+import { CustomPriceSelect } from "../components/CustomPriceSelect";
 
 export function BudgetField() {
   const [, , dailyBudget] = useField<number>("dailyBudget");
   const { isDraft } = useIsEdit();
-  const { data, loading } = useAdvertiserWithPrices();
+  const { data } = useAdvertiserWithPrices();
   const { values, errors } = useFormikContext<CampaignForm>();
   const [minBudget, setMinBudget] = useState(MIN_PER_CAMPAIGN);
   const campaignRuntime = Math.floor(
@@ -69,46 +63,11 @@ export function BudgetField() {
           disabled={!isDraft && !data.selfServiceSetPrice}
         />
 
-        <Stack direction="column" spacing={2} alignItems="flex-start">
-          <FormikRadioControl
-            label="Billing Type"
-            name="billingModel"
-            options={data.prices
-              .filter((p) => p.format === values.format)
-              .map((p) => ({
-                label: uiLabelsForBillingType(p.billingType).longLabel,
-                value: { price: p.billingModelPrice, type: p.billingType },
-              }))}
-            disabled={
-              loading ||
-              !isDraft ||
-              values.format === CampaignFormat.NewsDisplayAd
-            }
-          />
-          {!data.selfServiceSetPrice ? (
-            <Typography variant="body2">
-              {uiTextForCampaignFormat(values.format)} campaigns are priced at a
-              flat rate of{" "}
-              <strong>
-                ${values.price} {_.upperCase(values.type)}
-              </strong>
-              .
-            </Typography>
-          ) : (
-            <FormikTextField
-              fullWidth={false}
-              name="price"
-              label="Price"
-              type="number"
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">$</InputAdornment>
-                ),
-              }}
-              disabled={!isDraft}
-            />
-          )}
-        </Stack>
+        {!data.selfServiceSetPrice && (
+          <BillingModelSelect prices={data.prices} />
+        )}
+
+        {data.selfServiceSetPrice && <CustomPriceSelect />}
       </Stack>
     </CardContainer>
   );

--- a/src/user/views/adsManager/views/advanced/components/campaign/fields/FormatField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/fields/FormatField.tsx
@@ -39,7 +39,8 @@ const FormatItemButton = (props: { format: CampaignFormat } & PriceProps) => {
   const { isEdit } = useIsEdit();
   const [, meta, format] = useField<CampaignFormat>("format");
   const [, , price] = useField<string>("price");
-  const [, bMeta, billing] = useField<Billing>("billingType");
+  const [, , billing] = useField<Billing>("billingType");
+  const formatPrices = props.prices.filter((p) => p.format === props.format);
 
   return (
     <ListItemButton
@@ -47,18 +48,8 @@ const FormatItemButton = (props: { format: CampaignFormat } & PriceProps) => {
       selected={meta.value === props.format}
       onClick={() => {
         format.setValue(props.format);
-        const found = props.prices.find((p) => {
-          return (
-            p.format === props.format &&
-            p.billingType === bMeta.value.toUpperCase()
-          );
-        });
-        if (props.format === CampaignFormat.NewsDisplayAd) {
-          price.setValue(found?.billingModelPrice ?? "10");
-          billing.setValue("cpm");
-        } else {
-          price.setValue(found?.billingModelPrice ?? "6");
-        }
+        price.setValue(formatPrices[0].billingModelPrice);
+        billing.setValue(formatPrices[0].billingType);
       }}
       sx={{
         p: 2,

--- a/src/user/views/adsManager/views/advanced/components/campaign/fields/FormatField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/fields/FormatField.tsx
@@ -5,11 +5,11 @@ import { CampaignFormat } from "graphql/types";
 import _ from "lodash";
 import { useIsEdit } from "form/FormikHelpers";
 import { Billing } from "user/views/adsManager/types";
-import { AdvertiserPriceFragment } from "graphql/advertiser.generated";
 import { FormatHelp } from "components/Button/FormatHelp";
+import { AdvertiserPrice } from "user/hooks/useAdvertiserWithPrices";
 
 interface PriceProps {
-  prices: AdvertiserPriceFragment[];
+  prices: AdvertiserPrice[];
 }
 
 export function FormatField({ prices }: PriceProps) {

--- a/src/user/views/adsManager/views/advanced/components/campaign/fields/FormatField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/fields/FormatField.tsx
@@ -46,10 +46,10 @@ const FormatItemButton = (props: { format: CampaignFormat } & PriceProps) => {
     <ListItemButton
       disabled={isEdit}
       selected={meta.value === props.format}
-      onClick={() => {
-        format.setValue(props.format);
-        price.setValue(formatPrices[0].billingModelPrice);
-        billing.setValue(formatPrices[0].billingType);
+      onClick={async () => {
+        await format.setValue(props.format);
+        await price.setValue(formatPrices[0].billingModelPrice);
+        await billing.setValue(formatPrices[0].billingType);
       }}
       sx={{
         p: 2,

--- a/src/user/views/adsManager/views/advanced/components/form/components/BaseForm.tsx
+++ b/src/user/views/adsManager/views/advanced/components/form/components/BaseForm.tsx
@@ -10,11 +10,11 @@ import { Route, Switch, useRouteMatch } from "react-router-dom";
 import { BudgetSettings } from "user/views/adsManager/views/advanced/components/campaign/BudgetSettings";
 import { FormContext } from "state/context";
 import { useState } from "react";
-import { AdvertiserPriceFragment } from "graphql/advertiser.generated";
+import { AdvertiserPrice } from "user/hooks/useAdvertiserWithPrices";
 
 interface Props {
   hasPaymentIntent?: boolean | null;
-  prices: AdvertiserPriceFragment[];
+  prices: AdvertiserPrice[];
 }
 
 export function BaseForm({ hasPaymentIntent, prices }: Props) {

--- a/src/util/billingType.ts
+++ b/src/util/billingType.ts
@@ -15,7 +15,9 @@ export function uiLabelsForBillingType(
   if (!billingType) {
     return { value: "N/A", shortLabel: "N/A", longLabel: "Unknown" };
   }
-  const entry = BILLING_TYPES.find((bt) => bt.value === billingType);
+  const entry = BILLING_TYPES.find(
+    (bt) => bt.value === billingType || bt.shortLabel === billingType,
+  );
   return (
     entry ?? {
       value: billingType,

--- a/src/util/billingType.ts
+++ b/src/util/billingType.ts
@@ -7,7 +7,7 @@ interface BillingTypeLabels {
 const BILLING_TYPES = [
   { value: "cpm", shortLabel: "CPM", longLabel: "CPM (Views)" },
   { value: "cpc", shortLabel: "CPC", longLabel: "CPC (Clicks)" },
-  { value: "cpv", shortLabel: "CPV", longLabel: "CPV (Visits)" },
+  { value: "cpsv", shortLabel: "CPSV", longLabel: "CPSV (Site Visits)" },
 ];
 export function uiLabelsForBillingType(
   billingType: string | undefined | null,

--- a/src/util/billingType.ts
+++ b/src/util/billingType.ts
@@ -5,7 +5,7 @@ interface BillingTypeLabels {
 }
 
 const BILLING_TYPES = [
-  { value: "cpm", shortLabel: "CPM", longLabel: "CPM (Views)" },
+  { value: "cpm", shortLabel: "CPM", longLabel: "CPM (Impressions)" },
   { value: "cpc", shortLabel: "CPC", longLabel: "CPC (Clicks)" },
   { value: "cpsv", shortLabel: "CPSV", longLabel: "CPSV (Site Visits)" },
 ];

--- a/src/util/campaign.ts
+++ b/src/util/campaign.ts
@@ -1,0 +1,13 @@
+import { CampaignFormat } from "graphql/types";
+
+export const CAMPAIGN_FORMATS = [
+  { value: CampaignFormat.PushNotification, label: "Push Notification" },
+  { value: CampaignFormat.NtpSi, label: "New Tab Takeover" },
+  { value: CampaignFormat.NewsDisplayAd, label: "News Display" },
+  { value: CampaignFormat.Search, label: "Search" },
+  { value: CampaignFormat.SearchHomepage, label: "Search Homepage" },
+];
+
+export function uiLabelsForCampaignFormat(format: CampaignFormat): string {
+  return CAMPAIGN_FORMATS.find((f) => f.value === format)?.label ?? format;
+}

--- a/src/validation/CampaignSchema.test.ts
+++ b/src/validation/CampaignSchema.test.ts
@@ -13,8 +13,23 @@ const prices: AdvertiserPrice[] = [
   },
   {
     format: CampaignFormat.PushNotification,
-    billingModelPrice: ".15",
+    billingModelPrice: "0.15",
     billingType: "cpc",
+  },
+  {
+    format: CampaignFormat.PushNotification,
+    billingModelPrice: "3",
+    billingType: "cpsv",
+  },
+  {
+    format: CampaignFormat.NewsDisplayAd,
+    billingModelPrice: "10",
+    billingType: "cpm",
+  },
+  {
+    format: CampaignFormat.NewsDisplayAd,
+    billingModelPrice: "3",
+    billingType: "cpsv",
   },
 ];
 
@@ -41,47 +56,74 @@ it("should pass on a valid object", () => {
 });
 
 it("should fail if the campaign start date is in past", () => {
-  const c = produce(validCampaign, (draft) => {
+  const nextState = produce(validCampaign, (draft) => {
     draft.startAt = parseISO("2020-07-18");
   });
 
   expect(() =>
-    CampaignSchema(prices).validateSync(c),
+    CampaignSchema(prices).validateSync(nextState),
   ).toThrowErrorMatchingInlineSnapshot(
     '"Start Date must be minimum of 2 days from today"',
   );
 });
 
 describe("pricing tests", () => {
-  it("should fail if the campaign price is less than allowed price", () => {
-    const c = produce(validCampaign, (draft) => {
-      draft.price = "5";
+  it.each([
+    { price: "6", format: CampaignFormat.PushNotification, billing: "cpm" },
+    { price: ".15", format: CampaignFormat.PushNotification, billing: "cpc" },
+    { price: "3", format: CampaignFormat.PushNotification, billing: "cpsv" },
+    { price: "10", format: CampaignFormat.NewsDisplayAd, billing: "cpm" },
+    { price: "3", format: CampaignFormat.NewsDisplayAd, billing: "cpsv" },
+  ])(
+    "success cases: $format with price $price and config $billing should pass",
+    async ({ price, format, billing }) => {
+      const nextState = produce(validCampaign, (draft) => {
+        draft.price = price;
+        draft.format = format;
+        draft.billingType = billing;
+      });
+
+      expect(() =>
+        CampaignSchema(prices).validateSync(nextState),
+      ).not.toThrowError();
+    },
+  );
+
+  it.each([
+    { price: "5", format: CampaignFormat.PushNotification, billing: "cpm" },
+    { price: ".10", format: CampaignFormat.PushNotification, billing: "cpc" },
+    { price: "2", format: CampaignFormat.PushNotification, billing: "cpsv" },
+    { price: "9", format: CampaignFormat.NewsDisplayAd, billing: "cpm" },
+    { price: "2", format: CampaignFormat.NewsDisplayAd, billing: "cpsv" },
+  ])(
+    "failure cases: $format with price $price and config $billing should fail",
+    async ({ price, format, billing }) => {
+      const nextState = produce(validCampaign, (draft) => {
+        draft.price = price;
+        draft.format = format;
+        draft.billingType = billing;
+      });
+
+      const priceFound = prices.find(
+        (p) => p.billingType === billing && p.format === format,
+      );
+      expect(() => CampaignSchema(prices).validateSync(nextState)).toThrowError(
+        `${billing} price must be ${priceFound?.billingModelPrice} or higher`,
+      );
+    },
+  );
+
+  it("should fail prices if none found in array", () => {
+    const nextState = produce(validCampaign, (draft) => {
+      draft.price = ".15";
+      draft.format = CampaignFormat.NewsDisplayAd;
+      draft.billingType = "cpc";
     });
 
     expect(() =>
-      CampaignSchema(prices).validateSync(c),
-    ).toThrowErrorMatchingInlineSnapshot('"cpm price must be 6 or higher"');
-  });
-
-  it("should validate against default if none found", () => {
-    const c = produce(validCampaign, (draft) => {
-      (draft.format = CampaignFormat.NewsDisplayAd), (draft.price = "9");
-    });
-
-    expect(() =>
-      CampaignSchema(prices).validateSync(c),
-    ).toThrowErrorMatchingInlineSnapshot('"cpm price must be 10 or higher"');
-  });
-
-  it("should validate against default if none found", () => {
-    const c = produce(validCampaign, (draft) => {
-      (draft.format = CampaignFormat.NewsDisplayAd),
-        (draft.billingType = "cpc");
-      draft.price = ".1";
-    });
-
-    expect(() =>
-      CampaignSchema(prices).validateSync(c),
-    ).toThrowErrorMatchingInlineSnapshot('"cpc price must be 0.15 or higher"');
+      CampaignSchema(prices).validateSync(nextState),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"No cpc pricing available for News Display, contact selfserve@brave.com for help"',
+    );
   });
 });

--- a/src/validation/CampaignSchema.test.ts
+++ b/src/validation/CampaignSchema.test.ts
@@ -1,24 +1,20 @@
 import { parseISO } from "date-fns";
 import { produce } from "immer";
-import {
-  BillingType,
-  CampaignFormat,
-  CampaignPacingStrategies,
-} from "graphql/types";
+import { CampaignFormat, CampaignPacingStrategies } from "graphql/types";
 import { CampaignSchema } from "./CampaignSchema";
-import { AdvertiserPriceFragment } from "graphql/advertiser.generated";
 import { describe } from "vitest";
+import { AdvertiserPrice } from "user/hooks/useAdvertiserWithPrices";
 
-const prices: Omit<AdvertiserPriceFragment, "isDefault">[] = [
+const prices: AdvertiserPrice[] = [
   {
     format: CampaignFormat.PushNotification,
     billingModelPrice: "6",
-    billingType: BillingType.Cpm,
+    billingType: "cpm",
   },
   {
     format: CampaignFormat.PushNotification,
     billingModelPrice: ".15",
-    billingType: BillingType.Cpc,
+    billingType: "cpc",
   },
 ];
 

--- a/src/validation/CampaignSchema.test.ts
+++ b/src/validation/CampaignSchema.test.ts
@@ -60,7 +60,7 @@ describe("pricing tests", () => {
 
     expect(() =>
       CampaignSchema(prices).validateSync(c),
-    ).toThrowErrorMatchingInlineSnapshot('"CPM price must be 6 or higher"');
+    ).toThrowErrorMatchingInlineSnapshot('"cpm price must be 6 or higher"');
   });
 
   it("should validate against default if none found", () => {
@@ -70,7 +70,7 @@ describe("pricing tests", () => {
 
     expect(() =>
       CampaignSchema(prices).validateSync(c),
-    ).toThrowErrorMatchingInlineSnapshot('"CPM price must be 10 or higher"');
+    ).toThrowErrorMatchingInlineSnapshot('"cpm price must be 10 or higher"');
   });
 
   it("should validate against default if none found", () => {
@@ -82,6 +82,6 @@ describe("pricing tests", () => {
 
     expect(() =>
       CampaignSchema(prices).validateSync(c),
-    ).toThrowErrorMatchingInlineSnapshot('"CPC price must be 0.15 or higher"');
+    ).toThrowErrorMatchingInlineSnapshot('"cpc price must be 0.15 or higher"');
   });
 });

--- a/src/validation/CampaignSchema.tsx
+++ b/src/validation/CampaignSchema.tsx
@@ -13,14 +13,15 @@ import { startOfDay } from "date-fns";
 import { twoDaysOut } from "form/DateFieldHelpers";
 import { TrailingAsteriskRegex } from "validation/regex";
 import { CreativeSchema } from "validation/CreativeSchema";
-import { BillingType, CampaignFormat } from "graphql/types";
-import { AdvertiserPriceFragment } from "graphql/advertiser.generated";
+import { CampaignFormat } from "graphql/types";
 import BigNumber from "bignumber.js";
+import { AdvertiserPrice } from "user/hooks/useAdvertiserWithPrices";
+import { Billing } from "user/views/adsManager/types";
 
 export const MIN_PER_DAY = 33;
 export const MIN_PER_CAMPAIGN = 100;
 
-export const CampaignSchema = (prices: AdvertiserPriceFragment[]) =>
+export const CampaignSchema = (prices: AdvertiserPrice[]) =>
   object().shape({
     name: string().label("Campaign Name").required(),
     format: string()
@@ -81,7 +82,7 @@ export const CampaignSchema = (prices: AdvertiserPriceFragment[]) =>
           findPrice(
             prices,
             CampaignFormat.PushNotification,
-            BillingType.Cpc,
+            "cpc",
             "0.1",
             schema,
           ),
@@ -93,7 +94,7 @@ export const CampaignSchema = (prices: AdvertiserPriceFragment[]) =>
           findPrice(
             prices,
             CampaignFormat.PushNotification,
-            BillingType.Cpm,
+            "cpm",
             "6",
             schema,
           ),
@@ -102,13 +103,7 @@ export const CampaignSchema = (prices: AdvertiserPriceFragment[]) =>
         is: (b: string, f: CampaignFormat) =>
           b === "cpm" && f === CampaignFormat.NewsDisplayAd,
         then: (schema) =>
-          findPrice(
-            prices,
-            CampaignFormat.NewsDisplayAd,
-            BillingType.Cpm,
-            "10",
-            schema,
-          ),
+          findPrice(prices, CampaignFormat.NewsDisplayAd, "cpm", "10", schema),
       })
       .required("Price is a required field"),
     billingType: string()
@@ -176,9 +171,9 @@ export const CampaignSchema = (prices: AdvertiserPriceFragment[]) =>
   });
 
 export function findPrice(
-  prices: AdvertiserPriceFragment[],
+  prices: AdvertiserPrice[],
   format: CampaignFormat,
-  billingType: BillingType,
+  billingType: Billing,
   defaultPrice: string,
   schema: StringSchema<string | undefined, AnyObject, undefined, "">,
 ) {

--- a/src/validation/CampaignSchema.tsx
+++ b/src/validation/CampaignSchema.tsx
@@ -17,6 +17,7 @@ import { CampaignFormat } from "graphql/types";
 import BigNumber from "bignumber.js";
 import { AdvertiserPrice } from "user/hooks/useAdvertiserWithPrices";
 import { Billing } from "user/views/adsManager/types";
+import { uiLabelsForCampaignFormat } from "util/campaign";
 
 export const MIN_PER_DAY = 33;
 export const MIN_PER_CAMPAIGN = 100;
@@ -76,39 +77,18 @@ export const CampaignSchema = (prices: AdvertiserPrice[]) =>
       .default([]),
     price: string()
       .label("Price")
-      .when("billingType", {
-        is: (b: string) => b === "cpc",
-        then: (schema) =>
-          findPrice(
-            prices,
-            CampaignFormat.PushNotification,
-            "cpc",
-            "0.1",
-            schema,
-          ),
-      })
-      .when(["billingType", "format"], {
-        is: (b: string, f: CampaignFormat) =>
-          b === "cpm" && f === CampaignFormat.PushNotification,
-        then: (schema) =>
-          findPrice(
-            prices,
-            CampaignFormat.PushNotification,
-            "cpm",
-            "6",
-            schema,
-          ),
-      })
-      .when(["billingType", "format"], {
-        is: (b: string, f: CampaignFormat) =>
-          b === "cpm" && f === CampaignFormat.NewsDisplayAd,
-        then: (schema) =>
-          findPrice(prices, CampaignFormat.NewsDisplayAd, "cpm", "10", schema),
+      .when(["billingType", "format"], ([billingType, format], schema) => {
+        return validatePriceByBillingTypeAndFormat(
+          prices,
+          format,
+          billingType,
+          schema,
+        );
       })
       .required("Price is a required field"),
     billingType: string()
       .label("Pricing Type")
-      .oneOf(["cpm", "cpc"])
+      .oneOf(["cpm", "cpc", "cpsv"])
       .required("Pricing type is a required field"),
     adSets: array()
       .min(1)
@@ -170,17 +150,27 @@ export const CampaignSchema = (prices: AdvertiserPrice[]) =>
       ),
   });
 
-export function findPrice(
+export function validatePriceByBillingTypeAndFormat(
   prices: AdvertiserPrice[],
   format: CampaignFormat,
   billingType: Billing,
-  defaultPrice: string,
   schema: StringSchema<string | undefined, AnyObject, undefined, "">,
 ) {
   const found = prices.find(
     (p) => p.format === format && p.billingType === billingType,
   );
-  const price = BigNumber(found?.billingModelPrice ?? defaultPrice);
+
+  if (!found) {
+    return schema.test(
+      "is-defined",
+      `No ${billingType} pricing available for ${uiLabelsForCampaignFormat(
+        format,
+      )}, contact selfserve@brave.com for help`,
+      () => false,
+    );
+  }
+
+  const price = BigNumber(found.billingModelPrice);
   return schema.test(
     "is-lte-price",
     `${billingType} price must be ${price} or higher`,


### PR DESCRIPTION
Allows for an advertiser to choose between multiple billing types for a campaign

---

https://github.com/brave/ads-ui/assets/48930920/e4e64081-5144-4062-822b-7357ee32e411




