### PR TITLE
feat: change links in support section

### DIFF
--- a/src/components/AppBar/LandingPageAppBar.tsx
+++ b/src/components/AppBar/LandingPageAppBar.tsx
@@ -43,7 +43,7 @@ export function LandingPageAppBar() {
     {
       component: (
         <HelpLink
-          label="Learn"
+          label="About"
           props={{
             href: "https://brave.com/brave-ads",
             target: "_blank",

--- a/src/components/Drawer/MiniSideBar.tsx
+++ b/src/components/Drawer/MiniSideBar.tsx
@@ -208,23 +208,11 @@ export function SupportMenu({ usePlainLink }: SupportProps) {
       <Menu open={open} anchorEl={anchorEl} onClose={() => setAnchorEl(null)}>
         <MenuItem
           onClick={() => {
-            window.open(
-              "https://support.brave.com/hc/en-us/articles/14354133537421-How-do-I-use-Brave-Ads-Self-Serve-Beta-",
-              "_blank",
-              "noopener",
-            );
+            window.open("https://ads-help.brave.com/", "_blank", "noopener");
             setAnchorEl(null);
           }}
         >
-          Brave Ads Tutorial
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            window.open("https://brave.com/brave-ads", "_blank", "noopener");
-            setAnchorEl(null);
-          }}
-        >
-          Advertiser Resources
+          Help Center
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -232,7 +220,7 @@ export function SupportMenu({ usePlainLink }: SupportProps) {
             setAnchorEl(null);
           }}
         >
-          Email support:{" "}
+          Contact:{" "}
           <Link sx={{ ml: 1 }} underline="none">
             selfserve@brave.com
           </Link>


### PR DESCRIPTION
Updates links to point to ads-help.brave.com

---

![Screen Shot 2023-12-12 at 2 50 14 PM](https://github.com/brave/ads-ui/assets/48930920/6427f42c-f0e2-4f8d-8be2-a458f130a490)
