### PR TITLE
fix: svg breaks build CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "start": "vite",
     "build": "NODE_OPTIONS='--max-old-space-size=4096' vite build",
+    "preview": "vite preview --port 8080",
     "test": "vitest",
     "codegen": "graphql-codegen",
     "format": "prettier --write .",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -41,6 +41,8 @@ export default defineConfig(({ mode }) => {
       assetsDir: "static",
       chunkSizeWarningLimit: 3000,
       sourcemap: true,
+      // vite automagically decides whether to inline assets depending on their size. We are explicitly disabling this.
+      assetsInlineLimit: 0,
     },
     test: {
       // see https://vitest.dev/config/#globals


### PR DESCRIPTION
Resolves: SVG export from figma appears to no longer work on build of static assets

## Before

![Screen Shot 2024-01-22 at 4 38 23 PM](https://github.com/brave/ads-ui/assets/48930920/af83af12-07be-4a7e-a063-259f41b4f3f3)

## After

![Screen Shot 2024-01-22 at 4 39 42 PM](https://github.com/brave/ads-ui/assets/48930920/ae50d0e8-73f2-42af-8274-af762f91fd07)


