### PR TITLE
feat: filter NTT by default

### DIFF
--- a/src/components/Datagrid/stringFilterOperators.tsx
+++ b/src/components/Datagrid/stringFilterOperators.tsx
@@ -1,0 +1,19 @@
+import {
+  getGridStringOperators,
+  GridFilterInputValue,
+  GridFilterItem,
+} from "@mui/x-data-grid";
+
+export function stringFilterOperators() {
+  return [
+    {
+      label: "is not",
+      value: "not",
+      getApplyFilterFn: (field: GridFilterItem) => (params: any) =>
+        params.value !== field.value,
+      InputComponentProps: { type: "string" },
+      InputComponent: GridFilterInputValue,
+    },
+    ...getGridStringOperators(),
+  ];
+}

--- a/src/user/campaignList/CampaignList.tsx
+++ b/src/user/campaignList/CampaignList.tsx
@@ -25,6 +25,7 @@ import { EditButton } from "user/campaignList/EditButton";
 import { calculateMetric } from "user/analytics/analyticsOverview/lib/overview.library";
 import { StatsMetric } from "user/analytics/analyticsOverview/types";
 import { uiLabelsForCampaignFormat } from "util/campaign";
+import { stringFilterOperators } from "components/Datagrid/stringFilterOperators";
 
 interface Props {
   advertiser?: AdvertiserCampaignsFragment | null;
@@ -87,6 +88,7 @@ export function CampaignList({ advertiser }: Props) {
       align: "left",
       headerAlign: "left",
       width: 150,
+      filterOperators: stringFilterOperators(),
     },
     {
       field: "state",
@@ -254,6 +256,13 @@ export function CampaignList({ advertiser }: Props) {
         pagination: {
           paginationModel: {
             pageSize: 10,
+          },
+        },
+        filter: {
+          filterModel: {
+            items: [
+              { field: "format", operator: "not", value: "New tab takeover" },
+            ],
           },
         },
       }}


### PR DESCRIPTION
You cannot view reporting or any details on NTT in dashboard. Filter these by default.

MUI does not provide an `is not` operator, so we needed to create one.

---


![Screen Shot 2024-01-24 at 2 39 49 PM](https://github.com/brave/ads-ui/assets/48930920/c6886268-3409-42eb-b65d-d19cf35d3031)
