### PR TITLE
feat: make segment names fit better in their category

### DIFF
--- a/src/components/Segment/SegmentPicker.tsx
+++ b/src/components/Segment/SegmentPicker.tsx
@@ -26,6 +26,11 @@ export const SegmentPicker = ({ idx }: Props) => {
     `adSets.${idx}.segments`,
   );
 
+  const nameWithoutDash = (name: string) => {
+    const audienceWithChild = name.split("-");
+    return audienceWithChild[audienceWithChild.length - 1];
+  };
+
   useEffect(() => {
     if (targetMeta.value) {
       helper.setValue([{ code: "Svp7l-zGN", name: "untargeted" }]);
@@ -63,7 +68,7 @@ export const SegmentPicker = ({ idx }: Props) => {
                 style={{ marginRight: 8 }}
                 checked={selected}
               />
-              {option.name}
+              {nameWithoutDash(option.name)}
             </li>
           )}
           renderInput={(params) => (

--- a/src/user/adSet/AdSetList.tsx
+++ b/src/user/adSet/AdSetList.tsx
@@ -10,6 +10,7 @@ import { AdDetailTable } from "user/views/user/AdDetailTable";
 import { displayFromCampaignState } from "util/displayState";
 import { uiLabelsForBillingType } from "util/billingType";
 import { GridColDef } from "@mui/x-data-grid";
+import { segmentNameWithNoDash } from "util/segment";
 
 interface Props {
   loading: boolean;
@@ -136,7 +137,9 @@ export function AdSetList({ campaign, loading, engagements }: Props) {
         row.segments?.map((o: { name: string }) => o.name).join(", "),
       renderCell: ({ row }) => (
         <ChipList
-          items={row.segments}
+          items={row.segments.map((o) => ({
+            name: segmentNameWithNoDash(o.name),
+          }))}
           max={(row.segments ?? []).join("").length > 100 ? 2 : 5}
         />
       ),

--- a/src/user/views/adsManager/views/advanced/components/review/components/AdSetReview.tsx
+++ b/src/user/views/adsManager/views/advanced/components/review/components/AdSetReview.tsx
@@ -5,6 +5,7 @@ import { ReviewField } from "./ReviewField";
 import { ReviewContainer } from "user/views/adsManager/views/advanced/components/review/components/ReviewContainer";
 import { CampaignFormat } from "graphql/types";
 import { CreativeSpecificPreview } from "components/Creatives/CreativeSpecificPreview";
+import { segmentNameWithNoDash } from "util/segment";
 
 interface Props {
   idx: number;
@@ -23,7 +24,7 @@ export function AdSetReview({ adSet, idx, errors, format }: Props) {
   const adSetError = errors;
 
   const mapToString = (arr: Segment[] | OS[] | Creative[]) => {
-    return arr.map((o) => o.name).join(", ");
+    return arr.map((o) => segmentNameWithNoDash(o.name)).join(", ");
   };
 
   const segmentValue = (v: string) => {

--- a/src/util/segment.ts
+++ b/src/util/segment.ts
@@ -1,0 +1,8 @@
+export function segmentNameWithNoDash(name: string): string {
+  if (name === "Untargeted") return "Automatic targeting";
+  const audienceWithChild = name.split("-");
+  if (audienceWithChild.length === 1) return `${name} (general)`;
+  audienceWithChild.shift();
+
+  return audienceWithChild.join("-");
+}


### PR DESCRIPTION
Now that we have update segment casing, It makes sense that categories do not need a dash in them

## Before
![Screen Shot 2024-01-31 at 12 51 10 PM](https://github.com/brave/ads-ui/assets/48930920/64119e70-1df0-4eef-a8f4-48bd82f87f04)


## After
![Screen Shot 2024-01-31 at 12 45 09 PM](https://github.com/brave/ads-ui/assets/48930920/9ff96c22-be1b-4746-872a-7f896cd211d9)
