### PR TITLE
chore(graphql): rely on default values

### DIFF
--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -186,10 +186,10 @@ export type CreateAdvertiserImageInput = {
 
 export type CreateAdvertiserInput = {
   additionalBillingEmails?: InputMaybe<Array<Scalars["String"]["input"]>>;
-  billingAddress: CreateAddressInput;
+  billingAddress?: InputMaybe<CreateAddressInput>;
   billingEmail?: InputMaybe<Scalars["String"]["input"]>;
   billingModelPrices?: InputMaybe<Array<AdvertiserPriceInput>>;
-  mailingAddress: CreateAddressInput;
+  mailingAddress?: InputMaybe<CreateAddressInput>;
   name: Scalars["String"]["input"];
   phone?: InputMaybe<Scalars["String"]["input"]>;
   referrer?: InputMaybe<Scalars["String"]["input"]>;
@@ -205,7 +205,7 @@ export type CreateCampaignInput = {
   brandedKeyword?: InputMaybe<Scalars["String"]["input"]>;
   brandedKeywords?: InputMaybe<Array<Scalars["String"]["input"]>>;
   budget: Scalars["Float"]["input"];
-  currency: Scalars["String"]["input"];
+  currency?: Scalars["String"]["input"];
   dailyBudget?: InputMaybe<Scalars["Float"]["input"]>;
   dailyCap: Scalars["Float"]["input"];
   dayPartings?: InputMaybe<Array<DayPartingInput>>;
@@ -221,7 +221,7 @@ export type CreateCampaignInput = {
   source: Scalars["String"]["input"];
   startAt: Scalars["DateTime"]["input"];
   state: Scalars["String"]["input"];
-  type: Scalars["String"]["input"];
+  type?: Scalars["String"]["input"];
   userId?: InputMaybe<Scalars["String"]["input"]>;
 };
 

--- a/src/user/library/index.test.ts
+++ b/src/user/library/index.test.ts
@@ -236,7 +236,6 @@ describe("new form tests", () => {
     price: "6",
     startAt: dateString,
     state: "draft",
-    type: "paid",
     validateStart: false,
   };
 
@@ -284,11 +283,9 @@ describe("new form tests", () => {
           },
         ],
         "name": "Test",
-        "pacingStrategy": "MODEL_V1",
         "paymentType": "RADOM",
         "source": "self_serve",
         "state": "draft",
-        "type": "paid",
         "userId": "me",
       }
     `);
@@ -524,7 +521,6 @@ describe("edit form tests", () => {
         "price": "6000",
         "startAt": undefined,
         "state": "active",
-        "type": "paid",
         "validateStart": false,
       }
     `);
@@ -608,7 +604,6 @@ describe("edit form tests", () => {
         "paymentType": "RADOM",
         "startAt": undefined,
         "state": "active",
-        "type": "paid",
       }
     `);
   });

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -1,6 +1,5 @@
 import {
   CampaignFormat,
-  CampaignPacingStrategies,
   CreateCampaignInput,
   UpdateCampaignInput,
 } from "graphql/types";
@@ -37,7 +36,6 @@ export function transformNewForm(
     externalId: "",
     dailyCap: dailyLimit(form.format),
     endAt: form.endAt,
-    pacingStrategy: CampaignPacingStrategies.ModelV1,
     geoTargets: form.geoTargets.map((g) => ({ code: g.code, name: g.name })),
     name: form.name,
     advertiserId: form.advertiserId,
@@ -46,7 +44,6 @@ export function transformNewForm(
     source: "self_serve",
     startAt: form.startAt,
     state: form.state,
-    type: form.type,
     budget: form.budget,
     adSets: form.adSets.map((a) => ({
       ...transformAdSet(a, form),

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -135,7 +135,6 @@ export function editCampaignValues(
     name: campaign.name,
     startAt: campaign.startAt,
     state: campaign.state,
-    type: "paid",
     paymentType: campaign.paymentType,
   };
 }
@@ -216,7 +215,6 @@ export function transformEditForm(
     name: form.name,
     startAt: form.startAt,
     state: form.state,
-    type: form.type,
     paymentType: form.paymentType,
     adSets: form.adSets.map((adSet) => ({
       id: adSet.id,

--- a/src/user/views/adsManager/types/index.ts
+++ b/src/user/views/adsManager/types/index.ts
@@ -21,7 +21,6 @@ export type CampaignForm = {
   newCreative?: Creative;
   name: string;
   state: string;
-  type: "paid";
   // this is per click for CPC campaigns, but per thousand views for CPM campaigns
   price: string;
   billingType: Billing;
@@ -130,7 +129,6 @@ export const initialCampaign = (
     format: advertiser.prices[0].format,
     name: "",
     state: "draft",
-    type: "paid",
     paymentType: advertiser.selfServicePaymentType,
   };
 };


### PR DESCRIPTION
On campaign creation, rely on default values for for `pacingStrategy` and `type`

Re https://github.com/brave/ads-serve/issues/3675

Relies on https://github.com/brave/ads-serve/pull/3677