### PR TITLE
fix: make sure form initializes with existing address

### DIFF
--- a/src/auth/components/AdvertiserDetailsForm.tsx
+++ b/src/auth/components/AdvertiserDetailsForm.tsx
@@ -55,7 +55,7 @@ export function AdvertiserDetailsForm() {
               updateAdvertiserInput: {
                 id: advertiser.id,
                 agreed: v.terms && v.tracking && v.payment,
-                billingAddress: v.address,
+                billingAddress: v.address.id ? undefined : v.address,
               },
             },
           });

--- a/src/auth/components/AdvertiserDetailsForm.tsx
+++ b/src/auth/components/AdvertiserDetailsForm.tsx
@@ -15,6 +15,7 @@ import { PaymentType } from "graphql/types";
 import { AdvertiserAgreed } from "auth/components/AdvertiserAgreed";
 import { FormikSubmitButton } from "form/FormikButton";
 import { AdvertiserSchema } from "validation/AdvertiserSchema";
+import { useState } from "react";
 
 export function AdvertiserDetailsForm() {
   const history = useHistory();
@@ -23,6 +24,9 @@ export function AdvertiserDetailsForm() {
   const requiresPaymentAgree =
     advertiser.selfServiceManageCampaign &&
     advertiser.selfServicePaymentType !== PaymentType.Netsuite;
+  const [initial, setInitial] = useState<AdvertiserForm>(
+    initialAdvertiserForm(!requiresPaymentAgree),
+  );
 
   const [mutation] = useUpdateAdvertiserMutation({
     async onCompleted() {
@@ -34,17 +38,16 @@ export function AdvertiserDetailsForm() {
 
   const { data, loading } = useAdvertiserBillingAddressQuery({
     variables: { id: advertiser.id },
+    onCompleted: (data) => {
+      setInitial(initialAdvertiserForm(!requiresPaymentAgree, data.advertiser));
+    },
   });
-
-  const initial = initialAdvertiserForm(
-    !requiresPaymentAgree,
-    data?.advertiser,
-  );
 
   return (
     <Container maxWidth="lg" sx={{ mt: 5 }}>
       <Formik
         initialValues={initial}
+        enableReinitialize
         onSubmit={async (v: AdvertiserForm, { setSubmitting }) => {
           setSubmitting(true);
           await mutation({

--- a/src/auth/components/types.ts
+++ b/src/auth/components/types.ts
@@ -5,6 +5,7 @@ export type AdvertiserForm = {
   payment: boolean;
   terms: boolean;
   address: {
+    id?: string | null;
     street1: string;
     street2?: string | null;
     city: string;
@@ -18,15 +19,18 @@ type MaybeAddress = AdvertiserBillingAddressFragment;
 export const initialAdvertiserForm = (
   paymentAgree: boolean,
   maybeAddress?: MaybeAddress | null,
-): AdvertiserForm => ({
-  tracking: false,
-  payment: paymentAgree,
-  terms: false,
-  address: {
-    street1: maybeAddress?.billingAddress?.street1 ?? "",
-    city: maybeAddress?.billingAddress?.city ?? "",
-    state: maybeAddress?.billingAddress?.state ?? "",
-    country: maybeAddress?.billingAddress?.country ?? "",
-    zipcode: maybeAddress?.billingAddress?.zipcode ?? "",
-  },
-});
+): AdvertiserForm => {
+  return {
+    tracking: false,
+    payment: paymentAgree,
+    terms: false,
+    address: {
+      id: maybeAddress?.billingAddress?.id ?? null,
+      street1: maybeAddress?.billingAddress?.street1 ?? "",
+      city: maybeAddress?.billingAddress?.city ?? "",
+      state: maybeAddress?.billingAddress?.state ?? "",
+      country: maybeAddress?.billingAddress?.country ?? "",
+      zipcode: maybeAddress?.billingAddress?.zipcode ?? "",
+    },
+  };
+};

--- a/src/auth/components/types.ts
+++ b/src/auth/components/types.ts
@@ -22,13 +22,11 @@ export const initialAdvertiserForm = (
   tracking: false,
   payment: paymentAgree,
   terms: false,
-  address: maybeAddress?.billingAddress
-    ? { ...maybeAddress.billingAddress }
-    : {
-        street1: "",
-        city: "",
-        state: "",
-        country: "",
-        zipcode: "",
-      },
+  address: {
+    street1: maybeAddress?.billingAddress?.street1 ?? "",
+    city: maybeAddress?.billingAddress?.city ?? "",
+    state: maybeAddress?.billingAddress?.state ?? "",
+    country: maybeAddress?.billingAddress?.country ?? "",
+    zipcode: maybeAddress?.billingAddress?.zipcode ?? "",
+  },
 });

--- a/src/graphql/advertiser.generated.tsx
+++ b/src/graphql/advertiser.generated.tsx
@@ -17,6 +17,7 @@ export type AdvertiserSummaryFragment = {
 
 export type AdvertiserBillingAddressFragment = {
   billingAddress?: {
+    id: string;
     street1: string;
     street2?: string | null;
     city: string;
@@ -174,6 +175,7 @@ export type AdvertiserBillingAddressQuery = {
   advertiser?: {
     id: string;
     billingAddress?: {
+      id: string;
       street1: string;
       street2?: string | null;
       city: string;
@@ -195,6 +197,7 @@ export type UploadAdvertiserImageMutation = {
 export const AdvertiserBillingAddressFragmentDoc = gql`
   fragment AdvertiserBillingAddress on Advertiser {
     billingAddress {
+      id
       street1
       street2
       city

--- a/src/graphql/advertiser.graphql
+++ b/src/graphql/advertiser.graphql
@@ -11,6 +11,7 @@ fragment AdvertiserSummary on Advertiser {
 
 fragment AdvertiserBillingAddress on Advertiser {
   billingAddress {
+    id
     street1
     street2
     city

--- a/src/validation/AdvertiserSchema.tsx
+++ b/src/validation/AdvertiserSchema.tsx
@@ -11,6 +11,7 @@ export const AdvertiserSchema = object().shape({
     .default(false)
     .isTrue("Terms & Conditions acknowledgement is required"),
   address: object().shape({
+    id: string().nullable(),
     street1: string().label("Street address").required(),
     street2: string().label("Street address line 2").nullable(),
     city: string().label("City").required(),


### PR DESCRIPTION
Resolves issue where an advertiser can already have an address

---


https://github.com/brave/ads-ui/assets/48930920/09f9f758-eef5-4f4e-925c-20578ba28635

