### PR TITLE
fix: make sure advertiser can specify address

### DIFF
--- a/src/auth/components/AdvertiserAddress.tsx
+++ b/src/auth/components/AdvertiserAddress.tsx
@@ -1,58 +1,77 @@
-import { Box, Stack } from "@mui/material";
+import { Box, Divider, Stack } from "@mui/material";
 import { FormikTextField } from "form/FormikHelpers";
 import { CountryPicker } from "components/Country/CountryPicker";
 import { PropsWithChildren } from "react";
+import { AdvertiserBillingAddressFragment } from "graphql/advertiser.generated";
 
-export function AdvertiserAddress() {
+interface Props {
+  address: AdvertiserBillingAddressFragment["billingAddress"];
+}
+
+export function AdvertiserAddress({ address }: Props) {
+  if (address?.street1 && address?.country && address?.city) {
+    return null;
+  }
+
   return (
     <Box flexGrow={1}>
-      <StackedFields>
-        <FormikTextField
-          required
-          name="address.street1"
-          label="Street address"
-          autoComplete="address-line1"
-          margin="dense"
-        />
+      <Divider sx={{ mt: 1, mb: 1 }} />
+      {!address?.street1 && (
+        <StackedFields>
+          <FormikTextField
+            required
+            name="address.street1"
+            label="Street address"
+            autoComplete="address-line1"
+            margin="dense"
+          />
 
-        <FormikTextField
-          name="address.street2"
-          label="Street address line 2"
-          autoComplete="address-line2"
-          margin="dense"
-        />
-      </StackedFields>
+          <FormikTextField
+            name="address.street2"
+            label="Street address line 2"
+            autoComplete="address-line2"
+            margin="dense"
+          />
+        </StackedFields>
+      )}
 
-      <StackedFields>
-        <FormikTextField
-          required
-          name="address.city"
-          label="City"
-          autoComplete="address-level2"
-          margin="dense"
-        />
+      {!address?.city && (
+        <StackedFields>
+          <FormikTextField
+            required
+            name="address.city"
+            label="City"
+            autoComplete="address-level2"
+            margin="dense"
+          />
 
-        <FormikTextField
-          required
-          name="address.state"
-          label="State / Province"
-          autoComplete="address-level1"
-          margin="dense"
-        />
-      </StackedFields>
+          <FormikTextField
+            required
+            name="address.state"
+            label="State / Province"
+            autoComplete="address-level1"
+            margin="dense"
+          />
+        </StackedFields>
+      )}
 
-      <Stack direction={{ xs: "column", md: "row" }} spacing={{ xs: 0, md: 1 }}>
-        <CountryPicker name="address.country" />
+      {!address?.country && (
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={{ xs: 0, md: 1 }}
+        >
+          <CountryPicker name="address.country" />
 
-        <FormikTextField
-          required
-          name="address.zipcode"
-          label="Zip / Postal Code"
-          autoComplete="postal-code"
-          margin="dense"
-          fullWidth
-        />
-      </Stack>
+          <FormikTextField
+            required
+            name="address.zipcode"
+            label="Zip / Postal Code"
+            autoComplete="postal-code"
+            margin="dense"
+            fullWidth
+          />
+        </Stack>
+      )}
     </Box>
   );
 }

--- a/src/auth/components/AdvertiserDetailsForm.tsx
+++ b/src/auth/components/AdvertiserDetailsForm.tsx
@@ -102,13 +102,7 @@ export function AdvertiserDetailsForm() {
                   </Typography>
                 </Stack>
 
-                {!data?.advertiser?.billingAddress && (
-                  <>
-                    <Divider sx={{ mt: 1, mb: 1 }} />
-
-                    <AdvertiserAddress />
-                  </>
-                )}
+                <AdvertiserAddress address={data?.advertiser?.billingAddress} />
 
                 <Divider sx={{ mt: 1, mb: 1 }} />
 

--- a/src/validation/AdvertiserSchema.tsx
+++ b/src/validation/AdvertiserSchema.tsx
@@ -15,8 +15,8 @@ export const AdvertiserSchema = object().shape({
     street1: string().label("Street address").required(),
     street2: string().label("Street address line 2").nullable(),
     city: string().label("City").required(),
-    state: string().label("State / Province").required(),
+    state: string().label("State / Province").nullable(),
     country: string().label("Country").required(),
-    zipcode: string().label("Zip / Postal Code").required(),
+    zipcode: string().label("Zip / Postal Code").nullable(),
   }),
 });


### PR DESCRIPTION
Fixes issue where an advertiser may not be able to agree because they were missing required address details

---


https://github.com/brave/ads-ui/assets/48930920/4ca83b62-d574-4340-a789-e5bdb3311d8a

