### PR TITLE
chore: re-enable renovate major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,11 @@
     "schedule:weekends"
   ],
   "labels": ["dependencies"],
-  "postUpdateOptions": ["npmDedupe"]
+  "postUpdateOptions": ["npmDedupe"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
https://github.com/brave/renovate-config/pull/3 disabled this in the company config. Re-enable for this project.