### PR TITLE
fix: replace "ad campaign types" link on https://ads.brave.com/register

### DIFF
--- a/src/auth/registration/AccountChoice.tsx
+++ b/src/auth/registration/AccountChoice.tsx
@@ -50,7 +50,7 @@ export function AccountChoice() {
       <Link
         underline="none"
         variant="caption"
-        href="https://ads-help.brave.com/category/brave-browser"
+        href="https://ads-help.brave.com/category/ad-placements"
       >
         <Trans>Learn more about various campaign types</Trans>
       </Link>


### PR DESCRIPTION
Fixes #1128