### PR TITLE
feat(search): remove client-side domain validation

### DIFF
--- a/src/validation/RegistrationSchema.test.ts
+++ b/src/validation/RegistrationSchema.test.ts
@@ -19,14 +19,13 @@ it("should pass on a valid object", () => {
   RegistrationSchema("search").validateSync(validRegistration);
 });
 
-it("should fail if the domains do not match", () => {
+it("should not fail if the domains do not match", () => {
+  // as we perform this validation server-side
   const c = produce(validRegistration, (draft) => {
-    draft.domain = "google.com";
+    draft.domain = "basicattentiontoken.com";
   });
 
-  expect(() => RegistrationSchema("search").validateSync(c)).toThrowError(
-    "Domain must match the email domain",
-  );
+  RegistrationSchema("search").validateSync(c);
 });
 
 it("should fail if not an email", () => {

--- a/src/validation/RegistrationSchema.tsx
+++ b/src/validation/RegistrationSchema.tsx
@@ -36,16 +36,6 @@ const SearchRegistrationSchema = () =>
       .matches(
         DomainRegex,
         t`Please enter a valid domain, for example: brave.com`,
-      )
-      .test(
-        "is-matching-domain",
-        t`Domain must match the email domain`,
-        (value, context) => {
-          const email = context.parent.user.email;
-          if (!email) return false;
-          const splitEmail = email.split("@");
-          return value === splitEmail[splitEmail.length - 1];
-        },
       ),
     mediaSpend: string().optional().nullable(),
     country: string()


### PR DESCRIPTION
So that we can apply a more sophisticated version of these rules server-side only.