### PR TITLE
fix: extract translations

### DIFF
--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -198,6 +198,10 @@ msgstr "Ads are modular building blocks that can be paired with ad sets to build
 msgid "Advertiser Name"
 msgstr "Advertiser Name"
 
+#: src/user/views/user/search/SetupProgress.tsx:35
+msgid "Advertiser profile"
+msgstr "Advertiser profile"
+
 #: src/auth/views/LandingPage.tsx:33
 msgid "advertising made simple"
 msgstr "advertising made simple"
@@ -270,6 +274,7 @@ msgstr "Automatic interest targeting"
 #~ msgstr "Available Ad placements"
 
 #: src/components/Steps/NextAndBack.tsx:33
+#: src/user/views/user/search/SetupProgress.tsx:54
 msgid "Back"
 msgstr "Back"
 
@@ -402,7 +407,7 @@ msgstr "Campaign Name is required"
 msgid "Campaign Settings"
 msgstr "Campaign Settings"
 
-#: src/user/views/user/search/Summary.tsx:49
+#: src/user/views/user/search/SummaryPanel.tsx:54
 msgid "Campaign Summary"
 msgstr "Campaign Summary"
 
@@ -613,7 +618,7 @@ msgstr "Conversions"
 msgid "Copy this and keep this safe!"
 msgstr "Copy this and keep this safe!"
 
-#: src/user/views/user/search/Summary.tsx:62
+#: src/user/views/user/search/SummaryPanel.tsx:80
 msgid "Cost per click"
 msgstr "Cost per click"
 
@@ -656,7 +661,7 @@ msgid "Counted when an ad is displayed on screen for a minimum of one second"
 msgstr "Counted when an ad is displayed on screen for a minimum of one second"
 
 #: src/components/Country/CountryPicker.tsx:33
-#: src/user/views/user/search/Summary.tsx:52
+#: src/user/views/user/search/SummaryPanel.tsx:57
 msgid "Country"
 msgstr "Country"
 
@@ -781,7 +786,7 @@ msgstr "Dismissals"
 msgid "Documentation can be found <0>here</0> on how to use the API."
 msgstr "Documentation can be found <0>here</0> on how to use the API."
 
-#: src/user/views/user/search/Summary.tsx:57
+#: src/user/views/user/search/SummaryPanel.tsx:62
 msgid "Domain"
 msgstr "Domain"
 
@@ -910,6 +915,10 @@ msgstr "File upload complete for \"{fileName}\""
 msgid "Filter ads by name..."
 msgstr "Filter ads by name..."
 
+#: src/user/views/user/search/SetupProgress.tsx:50
+msgid "Finalize & submit"
+msgstr "Finalize & submit"
+
 #: src/validation/AdvertiserSchema.tsx:8
 msgid "First party tracking acknowledgement is required"
 msgstr "First party tracking acknowledgement is required"
@@ -946,6 +955,10 @@ msgstr "From a friend/colleague"
 #: src/auth/registration/MarketingChannel.tsx:28
 msgid "From an influential person I follow online"
 msgstr "From an influential person I follow online"
+
+#: src/user/views/user/search/LandingPageDetail.tsx:141
+msgid "Full Landing Page URL"
+msgstr "Full Landing Page URL"
 
 #: src/auth/registration/BrowserForm.tsx:15
 #: src/auth/registration/SearchForm.tsx:16
@@ -1350,6 +1363,11 @@ msgstr "no session created"
 msgid "Not automatically redirected? Click this link to go to the dashboard."
 msgstr "Not automatically redirected? Click this link to go to the dashboard."
 
+#: src/user/views/user/search/Finalize.tsx:33
+#: src/user/views/user/search/Finalize.tsx:36
+msgid "Notes"
+msgstr "Notes"
+
 #: src/user/library/index.ts:247
 #: src/util/campaign.ts:6
 msgid "Notification"
@@ -1596,6 +1614,10 @@ msgstr "Privacy-forward"
 msgid "Private Key"
 msgstr "Private Key"
 
+#: src/user/views/user/search/SetupProgress.tsx:44
+msgid "Proceed"
+msgstr "Proceed"
+
 #: src/components/Drawer/MiniSideBar.tsx:67
 msgid "Profile"
 msgstr "Profile"
@@ -1607,6 +1629,18 @@ msgstr "Profile API Key"
 #: src/user/settings/UserForm.tsx:36
 msgid "Profile Details"
 msgstr "Profile Details"
+
+#: src/user/views/user/search/Finalize.tsx:68
+msgid "Query parameter"
+msgstr "Query parameter"
+
+#: src/user/views/user/search/Finalize.tsx:48
+#~ msgid "Query string paramaters"
+#~ msgstr "Query string paramaters"
+
+#: src/user/views/user/search/Finalize.tsx:48
+msgid "Query string parameters"
+msgstr "Query string parameters"
 
 #: src/auth/views/LandingPage.tsx:37
 msgid "Reach and convert new customers through premium advertising on the Brave browser and search engine."
@@ -1648,9 +1682,17 @@ msgstr "Return to dashboard"
 msgid "Review"
 msgstr "Review"
 
+#: src/user/views/user/search/SetupProgress.tsx:40
+msgid "Review ads"
+msgstr "Review ads"
+
 #: src/search/SearchTalkingPoints.tsx:16
 #~ msgid "Risk Free"
 #~ msgstr "Risk Free"
+
+#: src/user/views/user/search/LandingPageDetail.tsx:149
+msgid "Sample Queries"
+msgstr "Sample Queries"
 
 #: src/form/FormikButton.tsx:71
 #: src/form/FormikButton.tsx:129
@@ -1724,9 +1766,17 @@ msgstr "Select the interest segments and platforms you would like to target."
 msgid "Select the platforms to target"
 msgstr "Select the platforms to target"
 
+#: src/user/views/user/search/SummaryPanel.tsx:67
+msgid "Selected ads"
+msgstr "Selected ads"
+
 #: src/auth/registration/AccountChoice.tsx:64
 #~ msgid "Self-service"
 #~ msgstr "Self-service"
+
+#: src/user/views/user/search/SetupProgress.tsx:29
+msgid "Setup Progress"
+msgstr "Setup Progress"
 
 #: src/user/analytics/analyticsOverview/components/MetricFilter.tsx:64
 msgid "Show"
@@ -1838,6 +1888,7 @@ msgstr "Street address is required"
 
 #: src/auth/registration/BrowserRegister.tsx:37
 #: src/auth/registration/SearchRegister.tsx:41
+#: src/user/views/user/search/SetupProgress.tsx:57
 msgid "Submit"
 msgstr "Submit"
 
@@ -1902,6 +1953,10 @@ msgstr "Terms & Conditions acknowledgement is required"
 #: src/auth/registration/AdvertiserRegistered.tsx:13
 #~ msgid "Thanks for your interest in Brave Ads! Our team will now carefully review the provided information."
 #~ msgstr "Thanks for your interest in Brave Ads! Our team will now carefully review the provided information."
+
+#: src/user/views/user/search/Finalize.tsx:50
+msgid "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
+msgstr "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:41
 #: src/user/analytics/search/metrics.ts:56
@@ -2070,8 +2125,8 @@ msgid "Unexpected error validating your credentials. Please try again later."
 msgstr "Unexpected error validating your credentials. Please try again later."
 
 #: src/user/views/user/search/Summary.tsx:67
-msgid "Unique ads"
-msgstr "Unique ads"
+#~ msgid "Unique ads"
+#~ msgstr "Unique ads"
 
 #: src/util/billingType.ts:13
 msgid "Unknown"
@@ -2139,6 +2194,10 @@ msgstr "Use existing ads"
 #: src/components/Url/UrlResolver.tsx:92
 msgid "Validating URL..."
 msgstr "Validating URL..."
+
+#: src/user/views/user/search/Finalize.tsx:73
+msgid "Value"
+msgstr "Value"
 
 #: src/user/reporting/ReportMenu.tsx:80
 msgid "Verified Conversions Report"
@@ -2233,6 +2292,10 @@ msgstr "Your organization’s new public key will be:"
 #: src/user/settings/NewKeyPairModal.tsx:103
 msgid "Your organization’s public key:"
 msgstr "Your organization’s public key:"
+
+#: src/user/views/user/search/Finalize.tsx:41
+msgid "Your trial campaign will be reviewed by an Account Manager. Add any notes or questions for them here."
+msgstr "Your trial campaign will be reviewed by an Account Manager. Add any notes or questions for them here."
 
 #: src/auth/components/AdvertiserAddress.tsx:51
 msgid "Zip / Postal Code"

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -194,6 +194,10 @@ msgstr "Los anuncios son bloques de construcción modulares que se pueden combin
 msgid "Advertiser Name"
 msgstr "Nombre del anunciante"
 
+#: src/user/views/user/search/SetupProgress.tsx:35
+msgid "Advertiser profile"
+msgstr ""
+
 #: src/auth/views/LandingPage.tsx:33
 msgid "advertising made simple"
 msgstr "Publicidad simplificada"
@@ -264,6 +268,7 @@ msgstr "Segmentación automática de intereses"
 #~ msgstr "Ubicaciones de anuncios disponibles"
 
 #: src/components/Steps/NextAndBack.tsx:33
+#: src/user/views/user/search/SetupProgress.tsx:54
 msgid "Back"
 msgstr "Atrás"
 
@@ -381,7 +386,7 @@ msgstr "Se requiere el nombre de la campaña"
 msgid "Campaign Settings"
 msgstr "Configuración de la campaña"
 
-#: src/user/views/user/search/Summary.tsx:49
+#: src/user/views/user/search/SummaryPanel.tsx:54
 msgid "Campaign Summary"
 msgstr ""
 
@@ -587,7 +592,7 @@ msgstr "Conversiones"
 msgid "Copy this and keep this safe!"
 msgstr "¡Copie esto y guárdelo en un lugar seguro!"
 
-#: src/user/views/user/search/Summary.tsx:62
+#: src/user/views/user/search/SummaryPanel.tsx:80
 msgid "Cost per click"
 msgstr ""
 
@@ -630,7 +635,7 @@ msgid "Counted when an ad is displayed on screen for a minimum of one second"
 msgstr "Se cuenta cuando un anuncio se muestra en la pantalla durante un mínimo de un segundo."
 
 #: src/components/Country/CountryPicker.tsx:33
-#: src/user/views/user/search/Summary.tsx:52
+#: src/user/views/user/search/SummaryPanel.tsx:57
 msgid "Country"
 msgstr "País"
 
@@ -754,7 +759,7 @@ msgstr "Rechazos"
 msgid "Documentation can be found <0>here</0> on how to use the API."
 msgstr "Puede encontrar documentación <0>aquí</0> sobre cómo usar la API."
 
-#: src/user/views/user/search/Summary.tsx:57
+#: src/user/views/user/search/SummaryPanel.tsx:62
 msgid "Domain"
 msgstr ""
 
@@ -883,6 +888,10 @@ msgstr "Carga de archivo completa para “{fileName}”"
 msgid "Filter ads by name..."
 msgstr "Filtrar anuncios por nombre…"
 
+#: src/user/views/user/search/SetupProgress.tsx:50
+msgid "Finalize & submit"
+msgstr ""
+
 #: src/validation/AdvertiserSchema.tsx:8
 msgid "First party tracking acknowledgement is required"
 msgstr "Se requiere el reconocimiento de seguimiento de origen"
@@ -917,6 +926,10 @@ msgstr "De un amigo/colega"
 #: src/auth/registration/MarketingChannel.tsx:28
 msgid "From an influential person I follow online"
 msgstr "De una persona influyente a la que sigo en línea"
+
+#: src/user/views/user/search/LandingPageDetail.tsx:141
+msgid "Full Landing Page URL"
+msgstr ""
 
 #: src/auth/registration/BrowserForm.tsx:15
 #: src/auth/registration/SearchForm.tsx:16
@@ -1307,6 +1320,11 @@ msgstr "no se ha creado ninguna sesión"
 msgid "Not automatically redirected? Click this link to go to the dashboard."
 msgstr "¿No se redirige automáticamente? Haga clic en este enlace para ir al panel de control."
 
+#: src/user/views/user/search/Finalize.tsx:33
+#: src/user/views/user/search/Finalize.tsx:36
+msgid "Notes"
+msgstr ""
+
 #: src/user/library/index.ts:247
 #: src/util/campaign.ts:6
 msgid "Notification"
@@ -1545,6 +1563,10 @@ msgstr "Orientado a la privacidad"
 msgid "Private Key"
 msgstr "Clave privada"
 
+#: src/user/views/user/search/SetupProgress.tsx:44
+msgid "Proceed"
+msgstr ""
+
 #: src/components/Drawer/MiniSideBar.tsx:67
 msgid "Profile"
 msgstr "Perfil"
@@ -1556,6 +1578,18 @@ msgstr "Clave API del perfil"
 #: src/user/settings/UserForm.tsx:36
 msgid "Profile Details"
 msgstr "Detalles del perfil"
+
+#: src/user/views/user/search/Finalize.tsx:68
+msgid "Query parameter"
+msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:48
+#~ msgid "Query string paramaters"
+#~ msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:48
+msgid "Query string parameters"
+msgstr ""
 
 #: src/auth/views/LandingPage.tsx:37
 msgid "Reach and convert new customers through premium advertising on the Brave browser and search engine."
@@ -1592,8 +1626,16 @@ msgstr "Volver al panel de control"
 msgid "Review"
 msgstr "Revisar"
 
+#: src/user/views/user/search/SetupProgress.tsx:40
+msgid "Review ads"
+msgstr ""
+
 #~ msgid "Risk Free"
 #~ msgstr "Sin riesgos"
+
+#: src/user/views/user/search/LandingPageDetail.tsx:149
+msgid "Sample Queries"
+msgstr ""
 
 #: src/form/FormikButton.tsx:71
 #: src/form/FormikButton.tsx:129
@@ -1663,8 +1705,16 @@ msgstr "Seleccione los segmentos de interés y las plataformas a las que desea d
 msgid "Select the platforms to target"
 msgstr "Seleccione las plataformas a las que se dirigirá"
 
+#: src/user/views/user/search/SummaryPanel.tsx:67
+msgid "Selected ads"
+msgstr ""
+
 #~ msgid "Self-service"
 #~ msgstr "Autoservicio"
+
+#: src/user/views/user/search/SetupProgress.tsx:29
+msgid "Setup Progress"
+msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricFilter.tsx:64
 msgid "Show"
@@ -1764,6 +1814,7 @@ msgstr "Se requiere la dirección de la calle"
 
 #: src/auth/registration/BrowserRegister.tsx:37
 #: src/auth/registration/SearchRegister.tsx:41
+#: src/user/views/user/search/SetupProgress.tsx:57
 msgid "Submit"
 msgstr "Enviar"
 
@@ -1821,6 +1872,10 @@ msgstr "Se requiere la aceptación de los Términos y Condiciones"
 
 #~ msgid "Thanks for your interest in Brave Ads! Our team will now carefully review the provided information."
 #~ msgstr "¡Gracias por su interés en Brave Ads! Nuestro equipo ahora revisará cuidadosamente la información proporcionada."
+
+#: src/user/views/user/search/Finalize.tsx:50
+msgid "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
+msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:41
 #: src/user/analytics/search/metrics.ts:56
@@ -1976,8 +2031,8 @@ msgid "Unexpected error validating your credentials. Please try again later."
 msgstr "Error inesperado al validar sus credenciales. Por favor, inténtelo de nuevo más tarde."
 
 #: src/user/views/user/search/Summary.tsx:67
-msgid "Unique ads"
-msgstr ""
+#~ msgid "Unique ads"
+#~ msgstr ""
 
 #: src/util/billingType.ts:13
 msgid "Unknown"
@@ -2045,6 +2100,10 @@ msgstr "Usar anuncios existentes"
 #: src/components/Url/UrlResolver.tsx:92
 msgid "Validating URL..."
 msgstr "Validando URL…"
+
+#: src/user/views/user/search/Finalize.tsx:73
+msgid "Value"
+msgstr ""
 
 #: src/user/reporting/ReportMenu.tsx:80
 msgid "Verified Conversions Report"
@@ -2133,6 +2192,10 @@ msgstr "La nueva clave pública de su organización será:"
 #: src/user/settings/NewKeyPairModal.tsx:103
 msgid "Your organization’s public key:"
 msgstr "La clave pública de su organización:"
+
+#: src/user/views/user/search/Finalize.tsx:41
+msgid "Your trial campaign will be reviewed by an Account Manager. Add any notes or questions for them here."
+msgstr ""
 
 #: src/auth/components/AdvertiserAddress.tsx:51
 msgid "Zip / Postal Code"

--- a/src/locales/pt.po
+++ b/src/locales/pt.po
@@ -194,6 +194,10 @@ msgstr "Anúncios são blocos de construção modulares que podem ser combinados
 msgid "Advertiser Name"
 msgstr "Nome do Anunciante"
 
+#: src/user/views/user/search/SetupProgress.tsx:35
+msgid "Advertiser profile"
+msgstr ""
+
 #: src/auth/views/LandingPage.tsx:33
 msgid "advertising made simple"
 msgstr "publicidade descomplicada"
@@ -258,6 +262,7 @@ msgid "Automatic interest targeting"
 msgstr "Direcionamento automático por interesse"
 
 #: src/components/Steps/NextAndBack.tsx:33
+#: src/user/views/user/search/SetupProgress.tsx:54
 msgid "Back"
 msgstr "Voltar"
 
@@ -366,7 +371,7 @@ msgstr "O nome da campanha é obrigatório"
 msgid "Campaign Settings"
 msgstr "Configurações da Campanha"
 
-#: src/user/views/user/search/Summary.tsx:49
+#: src/user/views/user/search/SummaryPanel.tsx:54
 msgid "Campaign Summary"
 msgstr ""
 
@@ -569,7 +574,7 @@ msgstr "Conversões"
 msgid "Copy this and keep this safe!"
 msgstr "Copie isso e guarde em um local seguro!"
 
-#: src/user/views/user/search/Summary.tsx:62
+#: src/user/views/user/search/SummaryPanel.tsx:80
 msgid "Cost per click"
 msgstr ""
 
@@ -612,7 +617,7 @@ msgid "Counted when an ad is displayed on screen for a minimum of one second"
 msgstr "Contado quando um anúncio é exibido na tela por no mínimo um segundo."
 
 #: src/components/Country/CountryPicker.tsx:33
-#: src/user/views/user/search/Summary.tsx:52
+#: src/user/views/user/search/SummaryPanel.tsx:57
 msgid "Country"
 msgstr "País"
 
@@ -733,7 +738,7 @@ msgstr "Dispensas"
 msgid "Documentation can be found <0>here</0> on how to use the API."
 msgstr "A documentação sobre como utilizar a API pode ser encontrada <0>aqui</0>."
 
-#: src/user/views/user/search/Summary.tsx:57
+#: src/user/views/user/search/SummaryPanel.tsx:62
 msgid "Domain"
 msgstr ""
 
@@ -861,6 +866,10 @@ msgstr "Upload de arquivo completo para \"{fileName}\""
 msgid "Filter ads by name..."
 msgstr "Filtrar anúncios por nome..."
 
+#: src/user/views/user/search/SetupProgress.tsx:50
+msgid "Finalize & submit"
+msgstr ""
+
 #: src/validation/AdvertiserSchema.tsx:8
 msgid "First party tracking acknowledgement is required"
 msgstr "É necessário concordar com o rastreamento interno do site"
@@ -889,6 +898,10 @@ msgstr "De um amigo/colega"
 #: src/auth/registration/MarketingChannel.tsx:28
 msgid "From an influential person I follow online"
 msgstr "De uma pessoa influente que sigo online"
+
+#: src/user/views/user/search/LandingPageDetail.tsx:141
+msgid "Full Landing Page URL"
+msgstr ""
 
 #: src/auth/registration/BrowserForm.tsx:15
 #: src/auth/registration/SearchForm.tsx:16
@@ -1261,6 +1274,11 @@ msgstr "nenhuma sessão criada"
 msgid "Not automatically redirected? Click this link to go to the dashboard."
 msgstr "Não foi redirecionado automaticamente? Clique neste link para acessar o dashboard."
 
+#: src/user/views/user/search/Finalize.tsx:33
+#: src/user/views/user/search/Finalize.tsx:36
+msgid "Notes"
+msgstr ""
+
 #: src/user/library/index.ts:247
 #: src/util/campaign.ts:6
 msgid "Notification"
@@ -1487,6 +1505,10 @@ msgstr "Privacidade avançada"
 msgid "Private Key"
 msgstr "Chave Privada"
 
+#: src/user/views/user/search/SetupProgress.tsx:44
+msgid "Proceed"
+msgstr ""
+
 #: src/components/Drawer/MiniSideBar.tsx:67
 msgid "Profile"
 msgstr "Perfil"
@@ -1498,6 +1520,18 @@ msgstr "Chave de API do Perfil"
 #: src/user/settings/UserForm.tsx:36
 msgid "Profile Details"
 msgstr "Detalhes do Perfil"
+
+#: src/user/views/user/search/Finalize.tsx:68
+msgid "Query parameter"
+msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:48
+#~ msgid "Query string paramaters"
+#~ msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:48
+msgid "Query string parameters"
+msgstr ""
 
 #: src/auth/views/LandingPage.tsx:37
 msgid "Reach and convert new customers through premium advertising on the Brave browser and search engine."
@@ -1530,6 +1564,14 @@ msgstr "Voltar ao dashboard"
 #: src/user/views/adsManager/views/advanced/components/form/components/BaseForm.tsx:37
 msgid "Review"
 msgstr "Revisão"
+
+#: src/user/views/user/search/SetupProgress.tsx:40
+msgid "Review ads"
+msgstr ""
+
+#: src/user/views/user/search/LandingPageDetail.tsx:149
+msgid "Sample Queries"
+msgstr ""
 
 #: src/form/FormikButton.tsx:71
 #: src/form/FormikButton.tsx:129
@@ -1598,6 +1640,14 @@ msgstr "Selecione os segmentos de interesse e plataformas que você deseja direc
 #: src/components/Platform/PlatformPicker.tsx:45
 msgid "Select the platforms to target"
 msgstr "Selecione as plataformas para direcionar"
+
+#: src/user/views/user/search/SummaryPanel.tsx:67
+msgid "Selected ads"
+msgstr ""
+
+#: src/user/views/user/search/SetupProgress.tsx:29
+msgid "Setup Progress"
+msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricFilter.tsx:64
 msgid "Show"
@@ -1697,6 +1747,7 @@ msgstr "O endereço é obrigatório"
 
 #: src/auth/registration/BrowserRegister.tsx:37
 #: src/auth/registration/SearchRegister.tsx:41
+#: src/user/views/user/search/SetupProgress.tsx:57
 msgid "Submit"
 msgstr "Enviar"
 
@@ -1745,6 +1796,10 @@ msgstr "Nos conte por que você está interessado no Brave Ads"
 #: src/validation/AdvertiserSchema.tsx:17
 msgid "Terms & Conditions acknowledgement is required"
 msgstr "É necessário concordar com os Termos e Condições"
+
+#: src/user/views/user/search/Finalize.tsx:50
+msgid "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
+msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:41
 #: src/user/analytics/search/metrics.ts:56
@@ -1897,8 +1952,8 @@ msgid "Unexpected error validating your credentials. Please try again later."
 msgstr "Erro inesperado ao validar suas credenciais. Por favor, tente novamente mais tarde."
 
 #: src/user/views/user/search/Summary.tsx:67
-msgid "Unique ads"
-msgstr ""
+#~ msgid "Unique ads"
+#~ msgstr ""
 
 #: src/util/billingType.ts:13
 msgid "Unknown"
@@ -1966,6 +2021,10 @@ msgstr "Usar anúncios existentes"
 #: src/components/Url/UrlResolver.tsx:92
 msgid "Validating URL..."
 msgstr "Validando URL..."
+
+#: src/user/views/user/search/Finalize.tsx:73
+msgid "Value"
+msgstr ""
 
 #: src/user/reporting/ReportMenu.tsx:80
 msgid "Verified Conversions Report"
@@ -2048,6 +2107,10 @@ msgstr "A nova chave pública da sua organização será:"
 #: src/user/settings/NewKeyPairModal.tsx:103
 msgid "Your organization’s public key:"
 msgstr "Chave pública da sua organização:"
+
+#: src/user/views/user/search/Finalize.tsx:41
+msgid "Your trial campaign will be reviewed by an Account Manager. Add any notes or questions for them here."
+msgstr ""
 
 #: src/auth/components/AdvertiserAddress.tsx:51
 msgid "Zip / Postal Code"

--- a/src/locales/test.po
+++ b/src/locales/test.po
@@ -194,6 +194,10 @@ msgstr ""
 msgid "Advertiser Name"
 msgstr ""
 
+#: src/user/views/user/search/SetupProgress.tsx:35
+msgid "Advertiser profile"
+msgstr ""
+
 #: src/auth/views/LandingPage.tsx:33
 msgid "advertising made simple"
 msgstr ""
@@ -258,6 +262,7 @@ msgid "Automatic interest targeting"
 msgstr ""
 
 #: src/components/Steps/NextAndBack.tsx:33
+#: src/user/views/user/search/SetupProgress.tsx:54
 msgid "Back"
 msgstr ""
 
@@ -366,7 +371,7 @@ msgstr ""
 msgid "Campaign Settings"
 msgstr ""
 
-#: src/user/views/user/search/Summary.tsx:49
+#: src/user/views/user/search/SummaryPanel.tsx:54
 msgid "Campaign Summary"
 msgstr ""
 
@@ -569,7 +574,7 @@ msgstr ""
 msgid "Copy this and keep this safe!"
 msgstr ""
 
-#: src/user/views/user/search/Summary.tsx:62
+#: src/user/views/user/search/SummaryPanel.tsx:80
 msgid "Cost per click"
 msgstr ""
 
@@ -612,7 +617,7 @@ msgid "Counted when an ad is displayed on screen for a minimum of one second"
 msgstr ""
 
 #: src/components/Country/CountryPicker.tsx:33
-#: src/user/views/user/search/Summary.tsx:52
+#: src/user/views/user/search/SummaryPanel.tsx:57
 msgid "Country"
 msgstr ""
 
@@ -733,7 +738,7 @@ msgstr ""
 msgid "Documentation can be found <0>here</0> on how to use the API."
 msgstr ""
 
-#: src/user/views/user/search/Summary.tsx:57
+#: src/user/views/user/search/SummaryPanel.tsx:62
 msgid "Domain"
 msgstr ""
 
@@ -862,6 +867,10 @@ msgstr ""
 msgid "Filter ads by name..."
 msgstr ""
 
+#: src/user/views/user/search/SetupProgress.tsx:50
+msgid "Finalize & submit"
+msgstr ""
+
 #: src/validation/AdvertiserSchema.tsx:8
 msgid "First party tracking acknowledgement is required"
 msgstr ""
@@ -889,6 +898,10 @@ msgstr ""
 
 #: src/auth/registration/MarketingChannel.tsx:28
 msgid "From an influential person I follow online"
+msgstr ""
+
+#: src/user/views/user/search/LandingPageDetail.tsx:141
+msgid "Full Landing Page URL"
 msgstr ""
 
 #: src/auth/registration/BrowserForm.tsx:15
@@ -1262,6 +1275,11 @@ msgstr ""
 msgid "Not automatically redirected? Click this link to go to the dashboard."
 msgstr ""
 
+#: src/user/views/user/search/Finalize.tsx:33
+#: src/user/views/user/search/Finalize.tsx:36
+msgid "Notes"
+msgstr ""
+
 #: src/user/library/index.ts:247
 #: src/util/campaign.ts:6
 msgid "Notification"
@@ -1488,6 +1506,10 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
+#: src/user/views/user/search/SetupProgress.tsx:44
+msgid "Proceed"
+msgstr ""
+
 #: src/components/Drawer/MiniSideBar.tsx:67
 msgid "Profile"
 msgstr ""
@@ -1498,6 +1520,18 @@ msgstr ""
 
 #: src/user/settings/UserForm.tsx:36
 msgid "Profile Details"
+msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:68
+msgid "Query parameter"
+msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:48
+#~ msgid "Query string paramaters"
+#~ msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:48
+msgid "Query string parameters"
 msgstr ""
 
 #: src/auth/views/LandingPage.tsx:37
@@ -1530,6 +1564,14 @@ msgstr ""
 
 #: src/user/views/adsManager/views/advanced/components/form/components/BaseForm.tsx:37
 msgid "Review"
+msgstr ""
+
+#: src/user/views/user/search/SetupProgress.tsx:40
+msgid "Review ads"
+msgstr ""
+
+#: src/user/views/user/search/LandingPageDetail.tsx:149
+msgid "Sample Queries"
 msgstr ""
 
 #: src/form/FormikButton.tsx:71
@@ -1598,6 +1640,14 @@ msgstr ""
 
 #: src/components/Platform/PlatformPicker.tsx:45
 msgid "Select the platforms to target"
+msgstr ""
+
+#: src/user/views/user/search/SummaryPanel.tsx:67
+msgid "Selected ads"
+msgstr ""
+
+#: src/user/views/user/search/SetupProgress.tsx:29
+msgid "Setup Progress"
 msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricFilter.tsx:64
@@ -1698,6 +1748,7 @@ msgstr ""
 
 #: src/auth/registration/BrowserRegister.tsx:37
 #: src/auth/registration/SearchRegister.tsx:41
+#: src/user/views/user/search/SetupProgress.tsx:57
 msgid "Submit"
 msgstr ""
 
@@ -1745,6 +1796,10 @@ msgstr ""
 
 #: src/validation/AdvertiserSchema.tsx:17
 msgid "Terms & Conditions acknowledgement is required"
+msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:50
+msgid "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
 msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:41
@@ -1898,8 +1953,8 @@ msgid "Unexpected error validating your credentials. Please try again later."
 msgstr ""
 
 #: src/user/views/user/search/Summary.tsx:67
-msgid "Unique ads"
-msgstr ""
+#~ msgid "Unique ads"
+#~ msgstr ""
 
 #: src/util/billingType.ts:13
 msgid "Unknown"
@@ -1966,6 +2021,10 @@ msgstr ""
 
 #: src/components/Url/UrlResolver.tsx:92
 msgid "Validating URL..."
+msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:73
+msgid "Value"
 msgstr ""
 
 #: src/user/reporting/ReportMenu.tsx:80
@@ -2048,6 +2107,10 @@ msgstr ""
 
 #: src/user/settings/NewKeyPairModal.tsx:103
 msgid "Your organization’s public key:"
+msgstr ""
+
+#: src/user/views/user/search/Finalize.tsx:41
+msgid "Your trial campaign will be reviewed by an Account Manager. Add any notes or questions for them here."
 msgstr ""
 
 #: src/auth/components/AdvertiserAddress.tsx:51

--- a/src/user/views/user/search/Finalize.tsx
+++ b/src/user/views/user/search/Finalize.tsx
@@ -45,7 +45,7 @@ export function Finalize() {
           }
         />
       </Section>
-      <Section title={msg`Query string paramaters`}>
+      <Section title={msg`Query string parameters`}>
         <Typography variant="body2">
           <Trans>
             The following query string parameters will be added to your landing


### PR DESCRIPTION
Apparently if you don't do this you get junk displayed after deployment. Going forward we need to make this less error-prone. But for now just run `npm run extract`.

Also fix a typo that I noticed while reviewing.

<img width="952" alt="Screenshot 2024-05-01 at 17 30 51" src="https://github.com/brave/ads-ui/assets/51444/8bf1af8e-6ad1-4159-9ffe-5d4af45d7834">

