### PR TITLE
chore(i18n): add in crowdin configuration file

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,3 @@
+files:
+  - source: /src/locales/en.po
+    translation: /src/locales/%two_letters_code%.po


### PR DESCRIPTION
We link to crowdin directly using a github connection, so the crowdin cli tools (and configuration of project & access token) are not required.

Once this is merged we may need to force a resync from the crowdin side.