### PR TITLE
fix: send budget and dates only if changed

### DIFF
--- a/src/user/library/index.test.ts
+++ b/src/user/library/index.test.ts
@@ -532,7 +532,11 @@ describe("edit form tests", () => {
   });
 
   it("should resolve to update input", () => {
-    const update = transformEditForm(editForm, editForm.id ?? "");
+    const update = transformEditForm(
+      editForm,
+      { budget: editForm.budget } as CampaignForm,
+      editForm.id ?? "",
+    );
     const sorted = {
       ...update,
       adSets: update.adSets?.sort(
@@ -602,7 +606,7 @@ describe("edit form tests", () => {
             "totalMax": 28,
           },
         ],
-        "budget": 100,
+        "budget": undefined,
         "endAt": undefined,
         "id": "000001",
         "name": "My first campaign",

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -199,14 +199,21 @@ export function validCreativeFields<T extends GenericCreative>(
 
 export function transformEditForm(
   form: CampaignForm,
+  initialValues: CampaignForm,
   id: string,
 ): UpdateCampaignInput {
+  function onlyIfChanged<F extends keyof CampaignForm>(
+    field: F,
+  ): CampaignForm[F] | undefined {
+    return form[field] !== initialValues[field] ? form[field] : undefined;
+  }
+
   return {
-    budget: form.budget,
-    endAt: form.endAt,
+    budget: onlyIfChanged("budget"),
+    endAt: onlyIfChanged("endAt"),
     id,
     name: form.name,
-    startAt: form.startAt,
+    startAt: onlyIfChanged("startAt"),
     state: form.state,
     paymentType: form.paymentType,
     adSets: form.adSets.map((adSet) => ({

--- a/src/user/views/adsManager/views/advanced/components/form/EditCampaign.tsx
+++ b/src/user/views/adsManager/views/advanced/components/form/EditCampaign.tsx
@@ -101,7 +101,7 @@ export function EditCampaign() {
         initialValues={initialValues}
         onSubmit={async (v: CampaignForm, { setSubmitting }) => {
           setSubmitting(true);
-          const input = transformEditForm(v, params.campaignId);
+          const input = transformEditForm(v, initialValues, params.campaignId);
           await mutation({ variables: { input } });
           setSubmitting(false);
         }}


### PR DESCRIPTION
Sending certain values if they have not changed can have unintended side effects. Send only if changed.