### PR TITLE
fix: remove min segments validation

### DIFF
--- a/src/validation/CampaignSchema.tsx
+++ b/src/validation/CampaignSchema.tsx
@@ -106,7 +106,6 @@ export const CampaignSchema = (prices: AdvertiserPrice[]) =>
                 name: string().required(),
               }),
             )
-            .min(1, t`At least one audience must be targeted`)
             .default([]),
           oses: array()
             .of(


### PR DESCRIPTION
The server no longer requires the "untargeted" segment configured, it adds it by default. So no need to validate that at 1 segment exists.