### PR TITLE
feat: adjust wording on campaign type selection screen

### DIFF
--- a/src/auth/registration/AccountChoice.tsx
+++ b/src/auth/registration/AccountChoice.tsx
@@ -81,7 +81,7 @@ export function AccountChoice() {
           <Link component={RouterLink} to="/contact" underline="none">
             contact us
           </Link>{" "}
-          for premium ad placements
+          for New Tab Takeover campaigns
         </Trans>
       </Typography>
     </AuthContainer>

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "{adFormatName} are not available for self-managed campaigns. Please contact sales to inquire."
 msgstr "{adFormatName} are not available for self-managed campaigns. Please contact sales to inquire."
 
-#: src/validation/CampaignSchema.tsx:188
+#: src/validation/CampaignSchema.tsx:187
 msgid "{billingType} price must be {price} or higher"
 msgstr "{billingType} price must be {price} or higher"
 
@@ -102,7 +102,7 @@ msgid "Ad format"
 msgstr "Ad format"
 
 #: src/components/Creatives/CreativeList.tsx:65
-#: src/user/campaignList/CampaignList.tsx:76
+#: src/user/campaignList/CampaignList.tsx:77
 msgid "Ad Format"
 msgstr "Ad Format"
 
@@ -138,7 +138,7 @@ msgstr "Ad sets"
 msgid "Ad Sets"
 msgstr "Ad Sets"
 
-#: src/validation/CampaignSchema.tsx:159
+#: src/validation/CampaignSchema.tsx:158
 msgid "Ad sets must have at least one ad"
 msgstr "Ad sets must have at least one ad"
 
@@ -163,7 +163,7 @@ msgstr "Ad type is required"
 msgid "Ad type must be notification or news"
 msgstr "Ad type must be notification or news"
 
-#: src/user/ads/AdsExistingAd.tsx:87
+#: src/user/ads/AdsExistingAd.tsx:76
 msgid "Add an existing ad"
 msgstr "Add an existing ad"
 
@@ -182,15 +182,15 @@ msgstr "Additional Report: OS Performance"
 #: src/components/AppBar/LandingPageAppBar.tsx:85
 #: src/components/Assets/AdvertiserAssets.tsx:33
 #: src/components/Creatives/CreativeList.tsx:102
-#: src/components/Creatives/CreativeSpecificPreview.tsx:52
-#: src/components/Creatives/CreativeSpecificPreview.tsx:63
+#: src/components/Creatives/CreativeSpecificPreview.tsx:54
+#: src/components/Creatives/CreativeSpecificPreview.tsx:65
 #: src/components/Drawer/MiniSideBar.tsx:32
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:29
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:30
 #: src/user/views/user/CampaignDetails.tsx:41
 msgid "Ads"
 msgstr "Ads"
 
-#: src/user/ads/AdsExistingAd.tsx:91
+#: src/user/ads/AdsExistingAd.tsx:80
 msgid "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
 msgstr "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
 
@@ -198,7 +198,7 @@ msgstr "Ads are modular building blocks that can be paired with ad sets to build
 msgid "Advertiser Name"
 msgstr "Advertiser Name"
 
-#: src/user/views/user/search/SetupProgress.tsx:35
+#: src/user/views/user/search/SetupProgress.tsx:34
 msgid "Advertiser profile"
 msgstr "Advertiser profile"
 
@@ -247,14 +247,14 @@ msgid "At a marketing/media conference"
 msgstr "At a marketing/media conference"
 
 #: src/validation/CampaignSchema.tsx:109
-msgid "At least one audience must be targeted"
-msgstr "At least one audience must be targeted"
+#~ msgid "At least one audience must be targeted"
+#~ msgstr "At least one audience must be targeted"
 
 #: src/validation/CampaignSchema.tsx:82
 msgid "At least one country must be targeted"
 msgstr "At least one country must be targeted"
 
-#: src/validation/CampaignSchema.tsx:118
+#: src/validation/CampaignSchema.tsx:117
 msgid "At least one platform must be targeted"
 msgstr "At least one platform must be targeted"
 
@@ -274,7 +274,7 @@ msgstr "Automatic interest targeting"
 #~ msgstr "Available Ad placements"
 
 #: src/components/Steps/NextAndBack.tsx:33
-#: src/user/views/user/search/SetupProgress.tsx:54
+#: src/user/views/user/search/SetupProgress.tsx:53
 msgid "Back"
 msgstr "Back"
 
@@ -333,7 +333,7 @@ msgid "Browser-based delivery offers a new way to reach audiences on the Web."
 msgstr "Browser-based delivery offers a new way to reach audiences on the Web."
 
 #: src/user/analytics/analyticsOverview/components/LiveFeed.tsx:52
-#: src/user/campaignList/CampaignList.tsx:96
+#: src/user/campaignList/CampaignList.tsx:97
 msgid "Budget"
 msgstr "Budget"
 
@@ -501,7 +501,7 @@ msgstr "Click-through rate"
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:35
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:164
 #: src/user/analytics/search/metrics.ts:46
-#: src/user/campaignList/CampaignList.tsx:132
+#: src/user/campaignList/CampaignList.tsx:133
 #: src/user/views/user/AdDetailTable.tsx:59
 msgid "Clicks"
 msgstr "Clicks"
@@ -579,23 +579,23 @@ msgstr "Conversion rate"
 msgid "Conversion Type"
 msgstr "Conversion Type"
 
-#: src/validation/CampaignSchema.tsx:152
+#: src/validation/CampaignSchema.tsx:151
 msgid "Conversion type must be Post Click or Post View"
 msgstr "Conversion type must be Post Click or Post View"
 
-#: src/validation/CampaignSchema.tsx:154
+#: src/validation/CampaignSchema.tsx:153
 msgid "Conversion type required."
 msgstr "Conversion type required."
 
-#: src/validation/CampaignSchema.tsx:141
+#: src/validation/CampaignSchema.tsx:140
 msgid "Conversion URL must end in trailing asterisk (*)"
 msgstr "Conversion URL must end in trailing asterisk (*)"
 
-#: src/validation/CampaignSchema.tsx:129
+#: src/validation/CampaignSchema.tsx:128
 msgid "Conversion URL must not contain any whitespace"
 msgstr "Conversion URL must not contain any whitespace"
 
-#: src/validation/CampaignSchema.tsx:133
+#: src/validation/CampaignSchema.tsx:132
 msgid "Conversion URL must start with https://"
 msgstr "Conversion URL must start with https://"
 
@@ -603,7 +603,7 @@ msgstr "Conversion URL must start with https://"
 msgid "Conversion URL Pattern"
 msgstr "Conversion URL Pattern"
 
-#: src/validation/CampaignSchema.tsx:126
+#: src/validation/CampaignSchema.tsx:125
 msgid "Conversion URL required."
 msgstr "Conversion URL required."
 
@@ -726,7 +726,6 @@ msgid "CTR"
 msgstr "CTR"
 
 #: src/auth/views/LandingPage.tsx:65
-#: src/components/Button/ContainedDashboardButton.tsx:8
 #: src/components/Button/DashboardButton.tsx:14
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -851,7 +850,7 @@ msgstr "Email"
 msgid "Email address is required"
 msgstr "Email address is required"
 
-#: src/user/campaignList/CampaignList.tsx:184
+#: src/user/campaignList/CampaignList.tsx:185
 msgid "End"
 msgstr "End"
 
@@ -911,11 +910,11 @@ msgstr "Feedback"
 msgid "File upload complete for \"{fileName}\""
 msgstr "File upload complete for \"{fileName}\""
 
-#: src/user/ads/AdsExistingAd.tsx:101
+#: src/user/ads/AdsExistingAd.tsx:90
 msgid "Filter ads by name..."
 msgstr "Filter ads by name..."
 
-#: src/user/views/user/search/SetupProgress.tsx:50
+#: src/user/views/user/search/SetupProgress.tsx:49
 msgid "Finalize & submit"
 msgstr "Finalize & submit"
 
@@ -1079,7 +1078,7 @@ msgstr "Images"
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:30
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:154
 #: src/user/analytics/search/metrics.ts:38
-#: src/user/campaignList/CampaignList.tsx:118
+#: src/user/campaignList/CampaignList.tsx:119
 #: src/user/views/user/AdDetailTable.tsx:47
 msgid "Impressions"
 msgstr "Impressions"
@@ -1198,8 +1197,8 @@ msgid "Limited time only. Available to new advertisers, and those who ran campai
 msgstr "Limited time only. Available to new advertisers, and those who ran campaigns before September 30, 2023."
 
 #: src/user/views/adsManager/views/advanced/components/campaign/fields/LocationField.tsx:8
-msgid "Location"
-msgstr "Location"
+#~ msgid "Location"
+#~ msgstr "Location"
 
 #: src/user/views/adsManager/views/advanced/components/review/components/CampaignReview.tsx:67
 msgid "Locations"
@@ -1306,8 +1305,8 @@ msgstr "New campaigns typically take up to 48 hours to review during a regular U
 msgid "New Keypair"
 msgstr "New Keypair"
 
-#: src/user/campaignList/CampaignList.tsx:262
-#: src/user/library/index.ts:248
+#: src/user/campaignList/CampaignList.tsx:263
+#: src/user/library/index.ts:255
 #: src/util/campaign.ts:7
 msgid "New tab takeover"
 msgstr "New tab takeover"
@@ -1316,7 +1315,7 @@ msgstr "New tab takeover"
 msgid "New tab takeovers"
 msgstr "New tab takeovers"
 
-#: src/user/library/index.ts:249
+#: src/user/library/index.ts:256
 #: src/util/campaign.ts:8
 msgid "Newsfeed"
 msgstr "Newsfeed"
@@ -1339,7 +1338,7 @@ msgstr "Next"
 msgid "No"
 msgstr "No"
 
-#: src/validation/CampaignSchema.tsx:180
+#: src/validation/CampaignSchema.tsx:179
 msgid "No {billingType} pricing available for {label}, contact selfserve@brave.com for help"
 msgstr "No {billingType} pricing available for {label}, contact selfserve@brave.com for help"
 
@@ -1351,7 +1350,7 @@ msgstr "No conversion URL setup"
 msgid "No file result"
 msgstr "No file result"
 
-#: src/user/ads/AdsExistingAd.tsx:78
+#: src/user/ads/AdsExistingAd.tsx:67
 msgid "No previous ads available"
 msgstr "No previous ads available"
 
@@ -1368,7 +1367,7 @@ msgstr "Not automatically redirected? Click this link to go to the dashboard."
 msgid "Notes"
 msgstr "Notes"
 
-#: src/user/library/index.ts:247
+#: src/user/library/index.ts:254
 #: src/util/campaign.ts:6
 msgid "Notification"
 msgstr "Notification"
@@ -1387,11 +1386,11 @@ msgstr "Notification ads"
 msgid "Observation Window"
 msgstr "Observation Window"
 
-#: src/validation/CampaignSchema.tsx:146
+#: src/validation/CampaignSchema.tsx:145
 msgid "Observation window must be 1, 7, or 30 days."
 msgstr "Observation window must be 1, 7, or 30 days."
 
-#: src/validation/CampaignSchema.tsx:148
+#: src/validation/CampaignSchema.tsx:147
 msgid "Observation window required."
 msgstr "Observation window required."
 
@@ -1404,7 +1403,7 @@ msgid "On a podcast I listen to"
 msgstr "On a podcast I listen to"
 
 #: src/user/adSet/AdSetList.tsx:83
-#: src/user/campaignList/CampaignList.tsx:196
+#: src/user/campaignList/CampaignList.tsx:197
 msgid "On/Off"
 msgstr "On/Off"
 
@@ -1417,8 +1416,12 @@ msgstr "Once confirmed, your organization’s keypair will be replaced with the 
 #~ msgstr "Once the review process is complete, we will send you an email to notify you of the approval status and any further steps required."
 
 #: src/auth/registration/AccountChoice.tsx:79
-msgid "or <0>contact us</0> for premium ad placements"
-msgstr "or <0>contact us</0> for premium ad placements"
+msgid "or <0>contact us</0> for New Tab Takeover campaigns"
+msgstr "or <0>contact us</0> for New Tab Takeover campaigns"
+
+#: src/auth/registration/AccountChoice.tsx:79
+#~ msgid "or <0>contact us</0> for premium ad placements"
+#~ msgstr "or <0>contact us</0> for premium ad placements"
 
 #: src/search/SearchLandingPage.tsx:82
 #~ msgid "Or email <0>searchads@brave.com</0>"
@@ -1508,7 +1511,7 @@ msgstr "Please enter a valid email address"
 msgid "Please enter a valid URL, for example https://brave.com"
 msgstr "Please enter a valid URL, for example https://brave.com"
 
-#: src/validation/CampaignSchema.tsx:137
+#: src/validation/CampaignSchema.tsx:136
 msgid "Please enter a valid URL, for example https://brave.com/product/*"
 msgstr "Please enter a valid URL, for example https://brave.com/product/*"
 
@@ -1614,7 +1617,7 @@ msgstr "Privacy-forward"
 msgid "Private Key"
 msgstr "Private Key"
 
-#: src/user/views/user/search/SetupProgress.tsx:44
+#: src/user/views/user/search/SetupProgress.tsx:43
 msgid "Proceed"
 msgstr "Proceed"
 
@@ -1682,7 +1685,7 @@ msgstr "Return to dashboard"
 msgid "Review"
 msgstr "Review"
 
-#: src/user/views/user/search/SetupProgress.tsx:40
+#: src/user/views/user/search/SetupProgress.tsx:39
 msgid "Review ads"
 msgstr "Review ads"
 
@@ -1718,12 +1721,12 @@ msgstr "Search ads"
 #~ msgid "Search domain must match email domain"
 #~ msgstr "Search domain must match email domain"
 
-#: src/user/library/index.ts:251
+#: src/user/library/index.ts:258
 #: src/util/campaign.ts:10
 msgid "Search homepage"
 msgstr "Search homepage"
 
-#: src/user/library/index.ts:250
+#: src/user/library/index.ts:257
 #: src/util/campaign.ts:9
 msgid "Search keyword"
 msgstr "Search keyword"
@@ -1745,7 +1748,7 @@ msgstr "Select one campaign to edit"
 msgid "Select Organization"
 msgstr "Select Organization"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:31
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:32
 msgid "Select the ads you would like to include in this ad set. Only checked ads are included."
 msgstr "Select the ads you would like to include in this ad set. Only checked ads are included."
 
@@ -1754,7 +1757,6 @@ msgid "Select the audience segments to target"
 msgstr "Select the audience segments to target"
 
 #: src/components/Location/LocationPicker.tsx:51
-#: src/user/views/adsManager/views/advanced/components/campaign/fields/LocationField.tsx:10
 msgid "Select the geographic regions where your ads will be shown."
 msgstr "Select the geographic regions where your ads will be shown."
 
@@ -1774,7 +1776,7 @@ msgstr "Selected ads"
 #~ msgid "Self-service"
 #~ msgstr "Self-service"
 
-#: src/user/views/user/search/SetupProgress.tsx:29
+#: src/user/views/user/search/SetupProgress.tsx:28
 msgid "Setup Progress"
 msgstr "Setup Progress"
 
@@ -1797,7 +1799,7 @@ msgstr "Site visit rate"
 #: src/user/analytics/analyticsOverview/components/BasePieChart.tsx:49
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:45
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:162
-#: src/user/campaignList/CampaignList.tsx:145
+#: src/user/campaignList/CampaignList.tsx:146
 msgid "Site visits"
 msgstr "Site visits"
 
@@ -1818,16 +1820,16 @@ msgstr "Something went wrong."
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:168
 #: src/user/analytics/analyticsOverview/reports/os/components/OsPieChart.tsx:40
 #: src/user/analytics/search/metrics.ts:63
-#: src/user/campaignList/CampaignList.tsx:105
+#: src/user/campaignList/CampaignList.tsx:106
 #: src/user/views/user/AdDetailTable.tsx:30
 msgid "Spend"
 msgstr "Spend"
 
-#: src/components/Creatives/SearchPreview.tsx:226
+#: src/components/Creatives/SearchPreview.tsx:247
 msgid "Sponsored"
 msgstr "Sponsored"
 
-#: src/user/campaignList/CampaignList.tsx:175
+#: src/user/campaignList/CampaignList.tsx:176
 msgid "Start"
 msgstr "Start"
 
@@ -1870,7 +1872,7 @@ msgstr "State"
 #: src/components/Creatives/CreativeCampaigns.tsx:48
 #: src/user/adSet/AdSetList.tsx:98
 #: src/user/analytics/search/AdSetBreakdown.tsx:73
-#: src/user/campaignList/CampaignList.tsx:85
+#: src/user/campaignList/CampaignList.tsx:86
 msgid "Status"
 msgstr "Status"
 
@@ -1888,7 +1890,7 @@ msgstr "Street address is required"
 
 #: src/auth/registration/BrowserRegister.tsx:37
 #: src/auth/registration/SearchRegister.tsx:41
-#: src/user/views/user/search/SetupProgress.tsx:57
+#: src/user/views/user/search/SetupProgress.tsx:56
 msgid "Submit"
 msgstr "Submit"
 

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "{adFormatName} are not available for self-managed campaigns. Please contact sales to inquire."
 msgstr "{adFormatName} no están disponibles para las campañas autogestionadas. Póngase en contacto con el departamento de ventas para consultar."
 
-#: src/validation/CampaignSchema.tsx:188
+#: src/validation/CampaignSchema.tsx:187
 msgid "{billingType} price must be {price} or higher"
 msgstr "{billingType} debe ser {price} o superior."
 
@@ -98,7 +98,7 @@ msgid "Ad format"
 msgstr "Formato del anuncio"
 
 #: src/components/Creatives/CreativeList.tsx:65
-#: src/user/campaignList/CampaignList.tsx:76
+#: src/user/campaignList/CampaignList.tsx:77
 msgid "Ad Format"
 msgstr "Formato del anuncio"
 
@@ -134,7 +134,7 @@ msgstr "Conjuntos de anuncios"
 msgid "Ad Sets"
 msgstr "Conjuntos de anuncios"
 
-#: src/validation/CampaignSchema.tsx:159
+#: src/validation/CampaignSchema.tsx:158
 msgid "Ad sets must have at least one ad"
 msgstr "Los conjuntos de anuncios deben tener al menos un anuncio"
 
@@ -159,7 +159,7 @@ msgstr "El tipo de anuncio es obligatorio"
 msgid "Ad type must be notification or news"
 msgstr "El tipo de anuncio debe ser notificación o noticias"
 
-#: src/user/ads/AdsExistingAd.tsx:87
+#: src/user/ads/AdsExistingAd.tsx:76
 msgid "Add an existing ad"
 msgstr "Añadir un anuncio existente"
 
@@ -178,15 +178,15 @@ msgstr "Informe adicional: Rendimiento del Sistema Operativo"
 #: src/components/AppBar/LandingPageAppBar.tsx:85
 #: src/components/Assets/AdvertiserAssets.tsx:33
 #: src/components/Creatives/CreativeList.tsx:102
-#: src/components/Creatives/CreativeSpecificPreview.tsx:52
-#: src/components/Creatives/CreativeSpecificPreview.tsx:63
+#: src/components/Creatives/CreativeSpecificPreview.tsx:54
+#: src/components/Creatives/CreativeSpecificPreview.tsx:65
 #: src/components/Drawer/MiniSideBar.tsx:32
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:29
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:30
 #: src/user/views/user/CampaignDetails.tsx:41
 msgid "Ads"
 msgstr "Anuncios"
 
-#: src/user/ads/AdsExistingAd.tsx:91
+#: src/user/ads/AdsExistingAd.tsx:80
 msgid "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
 msgstr "Los anuncios son bloques de construcción modulares que se pueden combinar con conjuntos de anuncios para crear combinaciones únicas. Los anuncios aprobados anteriormente se mostrarán aquí. Seleccione la casilla situada junto al nombre. Utilice el botón “Completar selección” para finalizar."
 
@@ -194,7 +194,7 @@ msgstr "Los anuncios son bloques de construcción modulares que se pueden combin
 msgid "Advertiser Name"
 msgstr "Nombre del anunciante"
 
-#: src/user/views/user/search/SetupProgress.tsx:35
+#: src/user/views/user/search/SetupProgress.tsx:34
 msgid "Advertiser profile"
 msgstr ""
 
@@ -242,14 +242,14 @@ msgid "At a marketing/media conference"
 msgstr "En una conferencia de marketing/medios de comunicación"
 
 #: src/validation/CampaignSchema.tsx:109
-msgid "At least one audience must be targeted"
-msgstr "Debe dirigirse al menos a una audiencia meta"
+#~ msgid "At least one audience must be targeted"
+#~ msgstr "Debe dirigirse al menos a una audiencia meta"
 
 #: src/validation/CampaignSchema.tsx:82
 msgid "At least one country must be targeted"
 msgstr "Debe dirigirse al menos a un país meta"
 
-#: src/validation/CampaignSchema.tsx:118
+#: src/validation/CampaignSchema.tsx:117
 msgid "At least one platform must be targeted"
 msgstr "Debe dirigirse al menos a una plataforma meta"
 
@@ -268,7 +268,7 @@ msgstr "Segmentación automática de intereses"
 #~ msgstr "Ubicaciones de anuncios disponibles"
 
 #: src/components/Steps/NextAndBack.tsx:33
-#: src/user/views/user/search/SetupProgress.tsx:54
+#: src/user/views/user/search/SetupProgress.tsx:53
 msgid "Back"
 msgstr "Atrás"
 
@@ -316,7 +316,7 @@ msgid "Browser-based delivery offers a new way to reach audiences on the Web."
 msgstr "La entrega basada en navegador ofrece una nueva forma de llegar a las audiencias en la Web."
 
 #: src/user/analytics/analyticsOverview/components/LiveFeed.tsx:52
-#: src/user/campaignList/CampaignList.tsx:96
+#: src/user/campaignList/CampaignList.tsx:97
 msgid "Budget"
 msgstr "Presupuesto"
 
@@ -475,7 +475,7 @@ msgstr "Tasa de clics"
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:35
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:164
 #: src/user/analytics/search/metrics.ts:46
-#: src/user/campaignList/CampaignList.tsx:132
+#: src/user/campaignList/CampaignList.tsx:133
 #: src/user/views/user/AdDetailTable.tsx:59
 msgid "Clicks"
 msgstr "Clics"
@@ -553,23 +553,23 @@ msgstr "Tasa de conversión"
 msgid "Conversion Type"
 msgstr "Tipo de conversión"
 
-#: src/validation/CampaignSchema.tsx:152
+#: src/validation/CampaignSchema.tsx:151
 msgid "Conversion type must be Post Click or Post View"
 msgstr "El tipo de conversión debe ser Post Clic o Post Vista"
 
-#: src/validation/CampaignSchema.tsx:154
+#: src/validation/CampaignSchema.tsx:153
 msgid "Conversion type required."
 msgstr "Se requiere el tipo de conversión."
 
-#: src/validation/CampaignSchema.tsx:141
+#: src/validation/CampaignSchema.tsx:140
 msgid "Conversion URL must end in trailing asterisk (*)"
 msgstr "La URL de conversión debe terminar con un asterisco final (*)"
 
-#: src/validation/CampaignSchema.tsx:129
+#: src/validation/CampaignSchema.tsx:128
 msgid "Conversion URL must not contain any whitespace"
 msgstr "La URL de conversión no debe contener espacios en blanco"
 
-#: src/validation/CampaignSchema.tsx:133
+#: src/validation/CampaignSchema.tsx:132
 msgid "Conversion URL must start with https://"
 msgstr "La URL de conversión debe comenzar con https://"
 
@@ -577,7 +577,7 @@ msgstr "La URL de conversión debe comenzar con https://"
 msgid "Conversion URL Pattern"
 msgstr "Patrón de URL de conversión"
 
-#: src/validation/CampaignSchema.tsx:126
+#: src/validation/CampaignSchema.tsx:125
 msgid "Conversion URL required."
 msgstr "Se requiere una URL de conversión."
 
@@ -699,7 +699,6 @@ msgid "CTR"
 msgstr "CTR"
 
 #: src/auth/views/LandingPage.tsx:65
-#: src/components/Button/ContainedDashboardButton.tsx:8
 #: src/components/Button/DashboardButton.tsx:14
 msgid "Dashboard"
 msgstr "Panel de control"
@@ -824,7 +823,7 @@ msgstr "Correo electrónico"
 msgid "Email address is required"
 msgstr "Se requiere una dirección de correo electrónico"
 
-#: src/user/campaignList/CampaignList.tsx:184
+#: src/user/campaignList/CampaignList.tsx:185
 msgid "End"
 msgstr "Finalización"
 
@@ -884,11 +883,11 @@ msgstr "Retroalimentación"
 msgid "File upload complete for \"{fileName}\""
 msgstr "Carga de archivo completa para “{fileName}”"
 
-#: src/user/ads/AdsExistingAd.tsx:101
+#: src/user/ads/AdsExistingAd.tsx:90
 msgid "Filter ads by name..."
 msgstr "Filtrar anuncios por nombre…"
 
-#: src/user/views/user/search/SetupProgress.tsx:50
+#: src/user/views/user/search/SetupProgress.tsx:49
 msgid "Finalize & submit"
 msgstr ""
 
@@ -1041,7 +1040,7 @@ msgstr "Imágenes"
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:30
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:154
 #: src/user/analytics/search/metrics.ts:38
-#: src/user/campaignList/CampaignList.tsx:118
+#: src/user/campaignList/CampaignList.tsx:119
 #: src/user/views/user/AdDetailTable.tsx:47
 msgid "Impressions"
 msgstr "Impresiones"
@@ -1158,8 +1157,8 @@ msgid "Limited time only. Available to new advertisers, and those who ran campai
 msgstr "Solo por tiempo limitado. Disponible para nuevos anunciantes y aquellos que realizaron campañas antes del 30 de septiembre de 2023."
 
 #: src/user/views/adsManager/views/advanced/components/campaign/fields/LocationField.tsx:8
-msgid "Location"
-msgstr "Ubicación"
+#~ msgid "Location"
+#~ msgstr "Ubicación"
 
 #: src/user/views/adsManager/views/advanced/components/review/components/CampaignReview.tsx:67
 msgid "Locations"
@@ -1263,8 +1262,8 @@ msgstr "Las nuevas campañas suelen tardar hasta 48 horas en revisarse durante u
 msgid "New Keypair"
 msgstr "Nuevo par de claves"
 
-#: src/user/campaignList/CampaignList.tsx:262
-#: src/user/library/index.ts:248
+#: src/user/campaignList/CampaignList.tsx:263
+#: src/user/library/index.ts:255
 #: src/util/campaign.ts:7
 msgid "New tab takeover"
 msgstr "Dominio de nueva pestaña"
@@ -1273,7 +1272,7 @@ msgstr "Dominio de nueva pestaña"
 msgid "New tab takeovers"
 msgstr "Dominio de nuevas pestañas"
 
-#: src/user/library/index.ts:249
+#: src/user/library/index.ts:256
 #: src/util/campaign.ts:8
 msgid "Newsfeed"
 msgstr "Fuente de noticias"
@@ -1296,7 +1295,7 @@ msgstr "Siguiente"
 msgid "No"
 msgstr "No"
 
-#: src/validation/CampaignSchema.tsx:180
+#: src/validation/CampaignSchema.tsx:179
 msgid "No {billingType} pricing available for {label}, contact selfserve@brave.com for help"
 msgstr "No hay precios de {billingType} disponibles para {label}, contacte a selfserve@brave.com para obtener ayuda"
 
@@ -1308,7 +1307,7 @@ msgstr "No hay configuración de URL de conversión"
 msgid "No file result"
 msgstr "No hay resultado del archivo"
 
-#: src/user/ads/AdsExistingAd.tsx:78
+#: src/user/ads/AdsExistingAd.tsx:67
 msgid "No previous ads available"
 msgstr "No hay anuncios anteriores disponibles"
 
@@ -1325,7 +1324,7 @@ msgstr "¿No se redirige automáticamente? Haga clic en este enlace para ir al p
 msgid "Notes"
 msgstr ""
 
-#: src/user/library/index.ts:247
+#: src/user/library/index.ts:254
 #: src/util/campaign.ts:6
 msgid "Notification"
 msgstr "Notificación"
@@ -1344,11 +1343,11 @@ msgstr "Anuncios de notificación"
 msgid "Observation Window"
 msgstr "Ventana de observación"
 
-#: src/validation/CampaignSchema.tsx:146
+#: src/validation/CampaignSchema.tsx:145
 msgid "Observation window must be 1, 7, or 30 days."
 msgstr "La ventana de observación debe ser de 1, 7 o 30 días."
 
-#: src/validation/CampaignSchema.tsx:148
+#: src/validation/CampaignSchema.tsx:147
 msgid "Observation window required."
 msgstr "Se requiere ventana de observación."
 
@@ -1361,7 +1360,7 @@ msgid "On a podcast I listen to"
 msgstr "En un podcast que escucho"
 
 #: src/user/adSet/AdSetList.tsx:83
-#: src/user/campaignList/CampaignList.tsx:196
+#: src/user/campaignList/CampaignList.tsx:197
 msgid "On/Off"
 msgstr "Encendido/Apagado"
 
@@ -1373,8 +1372,12 @@ msgstr "Una vez confirmado, el par de claves de su organización se reemplazará
 #~ msgstr "Una vez que se complete el proceso de revisión, le enviaremos un correo electrónico para notificarle el estado de aprobación y los pasos adicionales necesarios."
 
 #: src/auth/registration/AccountChoice.tsx:79
-msgid "or <0>contact us</0> for premium ad placements"
-msgstr "o <0>contáctenos</0> para ubicaciones de anuncios premium"
+msgid "or <0>contact us</0> for New Tab Takeover campaigns"
+msgstr ""
+
+#: src/auth/registration/AccountChoice.tsx:79
+#~ msgid "or <0>contact us</0> for premium ad placements"
+#~ msgstr "o <0>contáctenos</0> para ubicaciones de anuncios premium"
 
 #~ msgid "Or email <0>searchads@brave.com</0>"
 #~ msgstr "O envíe un correo electrónico a <0>searchads@brave.com</0>"
@@ -1463,7 +1466,7 @@ msgstr "Por favor, introduzca una dirección de correo electrónico válida"
 msgid "Please enter a valid URL, for example https://brave.com"
 msgstr "Por favor, introduzca una URL válida, por ejemplo, https://brave.com"
 
-#: src/validation/CampaignSchema.tsx:137
+#: src/validation/CampaignSchema.tsx:136
 msgid "Please enter a valid URL, for example https://brave.com/product/*"
 msgstr "Por favor, introduzca una URL válida, por ejemplo, https://brave.com/product/*"
 
@@ -1563,7 +1566,7 @@ msgstr "Orientado a la privacidad"
 msgid "Private Key"
 msgstr "Clave privada"
 
-#: src/user/views/user/search/SetupProgress.tsx:44
+#: src/user/views/user/search/SetupProgress.tsx:43
 msgid "Proceed"
 msgstr ""
 
@@ -1626,7 +1629,7 @@ msgstr "Volver al panel de control"
 msgid "Review"
 msgstr "Revisar"
 
-#: src/user/views/user/search/SetupProgress.tsx:40
+#: src/user/views/user/search/SetupProgress.tsx:39
 msgid "Review ads"
 msgstr ""
 
@@ -1657,12 +1660,12 @@ msgstr "Guardando…"
 msgid "Search ads"
 msgstr "Anuncios de búsqueda"
 
-#: src/user/library/index.ts:251
+#: src/user/library/index.ts:258
 #: src/util/campaign.ts:10
 msgid "Search homepage"
 msgstr "Buscar página de inicio"
 
-#: src/user/library/index.ts:250
+#: src/user/library/index.ts:257
 #: src/util/campaign.ts:9
 msgid "Search keyword"
 msgstr "Buscar palabra clave"
@@ -1684,7 +1687,7 @@ msgstr "Seleccione una campaña para editar"
 msgid "Select Organization"
 msgstr "Seleccione organización"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:31
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:32
 msgid "Select the ads you would like to include in this ad set. Only checked ads are included."
 msgstr "Seleccione los anuncios que desea incluir en este conjunto de anuncios. Solo se incluyen los anuncios marcados."
 
@@ -1693,7 +1696,6 @@ msgid "Select the audience segments to target"
 msgstr "Seleccione los segmentos de audiencia a los que desea dirigirse"
 
 #: src/components/Location/LocationPicker.tsx:51
-#: src/user/views/adsManager/views/advanced/components/campaign/fields/LocationField.tsx:10
 msgid "Select the geographic regions where your ads will be shown."
 msgstr "Seleccione las regiones geográficas en las que se mostrarán sus anuncios."
 
@@ -1712,7 +1714,7 @@ msgstr ""
 #~ msgid "Self-service"
 #~ msgstr "Autoservicio"
 
-#: src/user/views/user/search/SetupProgress.tsx:29
+#: src/user/views/user/search/SetupProgress.tsx:28
 msgid "Setup Progress"
 msgstr ""
 
@@ -1735,7 +1737,7 @@ msgstr "Tasa de visitas al sitio"
 #: src/user/analytics/analyticsOverview/components/BasePieChart.tsx:49
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:45
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:162
-#: src/user/campaignList/CampaignList.tsx:145
+#: src/user/campaignList/CampaignList.tsx:146
 msgid "Site visits"
 msgstr "Visitas al sitio"
 
@@ -1756,16 +1758,16 @@ msgstr "Algo salió mal. "
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:168
 #: src/user/analytics/analyticsOverview/reports/os/components/OsPieChart.tsx:40
 #: src/user/analytics/search/metrics.ts:63
-#: src/user/campaignList/CampaignList.tsx:105
+#: src/user/campaignList/CampaignList.tsx:106
 #: src/user/views/user/AdDetailTable.tsx:30
 msgid "Spend"
 msgstr "Gastar"
 
-#: src/components/Creatives/SearchPreview.tsx:226
+#: src/components/Creatives/SearchPreview.tsx:247
 msgid "Sponsored"
 msgstr ""
 
-#: src/user/campaignList/CampaignList.tsx:175
+#: src/user/campaignList/CampaignList.tsx:176
 msgid "Start"
 msgstr "Empezar"
 
@@ -1800,7 +1802,7 @@ msgstr "Estado"
 #: src/components/Creatives/CreativeCampaigns.tsx:48
 #: src/user/adSet/AdSetList.tsx:98
 #: src/user/analytics/search/AdSetBreakdown.tsx:73
-#: src/user/campaignList/CampaignList.tsx:85
+#: src/user/campaignList/CampaignList.tsx:86
 msgid "Status"
 msgstr "Estado"
 
@@ -1814,7 +1816,7 @@ msgstr "Se requiere la dirección de la calle"
 
 #: src/auth/registration/BrowserRegister.tsx:37
 #: src/auth/registration/SearchRegister.tsx:41
-#: src/user/views/user/search/SetupProgress.tsx:57
+#: src/user/views/user/search/SetupProgress.tsx:56
 msgid "Submit"
 msgstr "Enviar"
 

--- a/src/locales/pt.po
+++ b/src/locales/pt.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "{adFormatName} are not available for self-managed campaigns. Please contact sales to inquire."
 msgstr "{adFormatName} não estão disponíveis para campanhas autogerenciadas. Por favor, entre em contato com o time de vendas para obter mais informações."
 
-#: src/validation/CampaignSchema.tsx:188
+#: src/validation/CampaignSchema.tsx:187
 msgid "{billingType} price must be {price} or higher"
 msgstr "O preço de {billingType} deve ser {price} ou superior"
 
@@ -98,7 +98,7 @@ msgid "Ad format"
 msgstr "Formato do anúncio"
 
 #: src/components/Creatives/CreativeList.tsx:65
-#: src/user/campaignList/CampaignList.tsx:76
+#: src/user/campaignList/CampaignList.tsx:77
 msgid "Ad Format"
 msgstr "Formato do Anúncio"
 
@@ -134,7 +134,7 @@ msgstr "Conjuntos de anúncios"
 msgid "Ad Sets"
 msgstr "Conjuntos de Anúncios"
 
-#: src/validation/CampaignSchema.tsx:159
+#: src/validation/CampaignSchema.tsx:158
 msgid "Ad sets must have at least one ad"
 msgstr "Conjuntos de anúncios devem ter pelo menos um anúncio"
 
@@ -159,7 +159,7 @@ msgstr "O tipo de anúncio é obrigatório"
 msgid "Ad type must be notification or news"
 msgstr "O tipo de anúncio deve ser notificação ou notícia"
 
-#: src/user/ads/AdsExistingAd.tsx:87
+#: src/user/ads/AdsExistingAd.tsx:76
 msgid "Add an existing ad"
 msgstr "Adicionar um anúncio existente"
 
@@ -178,15 +178,15 @@ msgstr "Relatório Adicional: Desempenho do Sistema Operacional"
 #: src/components/AppBar/LandingPageAppBar.tsx:85
 #: src/components/Assets/AdvertiserAssets.tsx:33
 #: src/components/Creatives/CreativeList.tsx:102
-#: src/components/Creatives/CreativeSpecificPreview.tsx:52
-#: src/components/Creatives/CreativeSpecificPreview.tsx:63
+#: src/components/Creatives/CreativeSpecificPreview.tsx:54
+#: src/components/Creatives/CreativeSpecificPreview.tsx:65
 #: src/components/Drawer/MiniSideBar.tsx:32
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:29
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:30
 #: src/user/views/user/CampaignDetails.tsx:41
 msgid "Ads"
 msgstr "Anúncios"
 
-#: src/user/ads/AdsExistingAd.tsx:91
+#: src/user/ads/AdsExistingAd.tsx:80
 msgid "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
 msgstr "Anúncios são blocos de construção modulares que podem ser combinados com conjuntos de anúncios para criar combinações únicas. Seus anúncios previamente aprovados serão exibidos aqui. Selecione usando a caixa ao lado do nome. Use o botão \"Seleção Completa\" para concluir."
 
@@ -194,7 +194,7 @@ msgstr "Anúncios são blocos de construção modulares que podem ser combinados
 msgid "Advertiser Name"
 msgstr "Nome do Anunciante"
 
-#: src/user/views/user/search/SetupProgress.tsx:35
+#: src/user/views/user/search/SetupProgress.tsx:34
 msgid "Advertiser profile"
 msgstr ""
 
@@ -239,14 +239,14 @@ msgid "At a marketing/media conference"
 msgstr "Em uma conferência de marketing/mídia"
 
 #: src/validation/CampaignSchema.tsx:109
-msgid "At least one audience must be targeted"
-msgstr "Pelo menos um público-alvo deve ser direcionado"
+#~ msgid "At least one audience must be targeted"
+#~ msgstr "Pelo menos um público-alvo deve ser direcionado"
 
 #: src/validation/CampaignSchema.tsx:82
 msgid "At least one country must be targeted"
 msgstr "Pelo menos um país deve ser direcionado"
 
-#: src/validation/CampaignSchema.tsx:118
+#: src/validation/CampaignSchema.tsx:117
 msgid "At least one platform must be targeted"
 msgstr "Pelo menos uma plataforma deve ser direcionada"
 
@@ -262,7 +262,7 @@ msgid "Automatic interest targeting"
 msgstr "Direcionamento automático por interesse"
 
 #: src/components/Steps/NextAndBack.tsx:33
-#: src/user/views/user/search/SetupProgress.tsx:54
+#: src/user/views/user/search/SetupProgress.tsx:53
 msgid "Back"
 msgstr "Voltar"
 
@@ -301,7 +301,7 @@ msgid "Browser-based delivery offers a new way to reach audiences on the Web."
 msgstr "A entrega baseada no navegador oferece uma nova abordagem para alcançar o público online."
 
 #: src/user/analytics/analyticsOverview/components/LiveFeed.tsx:52
-#: src/user/campaignList/CampaignList.tsx:96
+#: src/user/campaignList/CampaignList.tsx:97
 msgid "Budget"
 msgstr "Orçamento"
 
@@ -457,7 +457,7 @@ msgstr "Taxa de Cliques"
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:35
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:164
 #: src/user/analytics/search/metrics.ts:46
-#: src/user/campaignList/CampaignList.tsx:132
+#: src/user/campaignList/CampaignList.tsx:133
 #: src/user/views/user/AdDetailTable.tsx:59
 msgid "Clicks"
 msgstr "Cliques"
@@ -535,23 +535,23 @@ msgstr "Taxa de conversão"
 msgid "Conversion Type"
 msgstr "Tipo de Conversão"
 
-#: src/validation/CampaignSchema.tsx:152
+#: src/validation/CampaignSchema.tsx:151
 msgid "Conversion type must be Post Click or Post View"
 msgstr "O tipo de conversão deve ser Pós-Clique ou Pós-Visualização"
 
-#: src/validation/CampaignSchema.tsx:154
+#: src/validation/CampaignSchema.tsx:153
 msgid "Conversion type required."
 msgstr "Tipo de conversão obrigatório."
 
-#: src/validation/CampaignSchema.tsx:141
+#: src/validation/CampaignSchema.tsx:140
 msgid "Conversion URL must end in trailing asterisk (*)"
 msgstr "A URL de conversão deve terminar com um asterisco (*)"
 
-#: src/validation/CampaignSchema.tsx:129
+#: src/validation/CampaignSchema.tsx:128
 msgid "Conversion URL must not contain any whitespace"
 msgstr "A URL de conversão não deve conter espaços em branco"
 
-#: src/validation/CampaignSchema.tsx:133
+#: src/validation/CampaignSchema.tsx:132
 msgid "Conversion URL must start with https://"
 msgstr "A URL de conversão deve começar com https://"
 
@@ -559,7 +559,7 @@ msgstr "A URL de conversão deve começar com https://"
 msgid "Conversion URL Pattern"
 msgstr "Padrão de URL de Conversão"
 
-#: src/validation/CampaignSchema.tsx:126
+#: src/validation/CampaignSchema.tsx:125
 msgid "Conversion URL required."
 msgstr "A URL de conversão é obrigatória."
 
@@ -678,7 +678,6 @@ msgid "CTR"
 msgstr "CTR (Taxa de Cliques)"
 
 #: src/auth/views/LandingPage.tsx:65
-#: src/components/Button/ContainedDashboardButton.tsx:8
 #: src/components/Button/DashboardButton.tsx:14
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -802,7 +801,7 @@ msgstr "E-mail"
 msgid "Email address is required"
 msgstr "Endereço de e-mail é obrigatório"
 
-#: src/user/campaignList/CampaignList.tsx:184
+#: src/user/campaignList/CampaignList.tsx:185
 msgid "End"
 msgstr "Fim"
 
@@ -862,11 +861,11 @@ msgstr "Feedback"
 msgid "File upload complete for \"{fileName}\""
 msgstr "Upload de arquivo completo para \"{fileName}\""
 
-#: src/user/ads/AdsExistingAd.tsx:101
+#: src/user/ads/AdsExistingAd.tsx:90
 msgid "Filter ads by name..."
 msgstr "Filtrar anúncios por nome..."
 
-#: src/user/views/user/search/SetupProgress.tsx:50
+#: src/user/views/user/search/SetupProgress.tsx:49
 msgid "Finalize & submit"
 msgstr ""
 
@@ -1010,7 +1009,7 @@ msgstr "Imagens"
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:30
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:154
 #: src/user/analytics/search/metrics.ts:38
-#: src/user/campaignList/CampaignList.tsx:118
+#: src/user/campaignList/CampaignList.tsx:119
 #: src/user/views/user/AdDetailTable.tsx:47
 msgid "Impressions"
 msgstr "Visualizações"
@@ -1121,8 +1120,8 @@ msgid "Limited time only. Available to new advertisers, and those who ran campai
 msgstr "Por tempo limitado. Disponível para novos anunciantes e aqueles que executaram campanhas antes de 30 de setembro de 2023."
 
 #: src/user/views/adsManager/views/advanced/components/campaign/fields/LocationField.tsx:8
-msgid "Location"
-msgstr "Localização"
+#~ msgid "Location"
+#~ msgstr "Localização"
 
 #: src/user/views/adsManager/views/advanced/components/review/components/CampaignReview.tsx:67
 msgid "Locations"
@@ -1217,8 +1216,8 @@ msgstr "Novas campanhas geralmente demoram até 48 horas para serem revisadas du
 msgid "New Keypair"
 msgstr "Novo Par de Chaves"
 
-#: src/user/campaignList/CampaignList.tsx:262
-#: src/user/library/index.ts:248
+#: src/user/campaignList/CampaignList.tsx:263
+#: src/user/library/index.ts:255
 #: src/util/campaign.ts:7
 msgid "New tab takeover"
 msgstr "Novo destaque de aba"
@@ -1227,7 +1226,7 @@ msgstr "Novo destaque de aba"
 msgid "New tab takeovers"
 msgstr "Novos destaques de aba"
 
-#: src/user/library/index.ts:249
+#: src/user/library/index.ts:256
 #: src/util/campaign.ts:8
 msgid "Newsfeed"
 msgstr "Feed de notícias"
@@ -1250,7 +1249,7 @@ msgstr "Próximo"
 msgid "No"
 msgstr "Não"
 
-#: src/validation/CampaignSchema.tsx:180
+#: src/validation/CampaignSchema.tsx:179
 msgid "No {billingType} pricing available for {label}, contact selfserve@brave.com for help"
 msgstr "Não há preços de {billingType} disponíveis para {label}, entre em contato com selfserve@brave.com para obter ajuda"
 
@@ -1262,7 +1261,7 @@ msgstr "Nenhuma configuração de URL de conversão"
 msgid "No file result"
 msgstr "Sem resultado de arquivo"
 
-#: src/user/ads/AdsExistingAd.tsx:78
+#: src/user/ads/AdsExistingAd.tsx:67
 msgid "No previous ads available"
 msgstr "Nenhum anúncio anterior disponível"
 
@@ -1279,7 +1278,7 @@ msgstr "Não foi redirecionado automaticamente? Clique neste link para acessar o
 msgid "Notes"
 msgstr ""
 
-#: src/user/library/index.ts:247
+#: src/user/library/index.ts:254
 #: src/util/campaign.ts:6
 msgid "Notification"
 msgstr "Notificação"
@@ -1298,11 +1297,11 @@ msgstr "Anúncios de notificação"
 msgid "Observation Window"
 msgstr "Janela de Observação"
 
-#: src/validation/CampaignSchema.tsx:146
+#: src/validation/CampaignSchema.tsx:145
 msgid "Observation window must be 1, 7, or 30 days."
 msgstr "A janela de observação deve ser de 1, 7 ou 30 dias."
 
-#: src/validation/CampaignSchema.tsx:148
+#: src/validation/CampaignSchema.tsx:147
 msgid "Observation window required."
 msgstr "A janela de observação é necessária."
 
@@ -1315,7 +1314,7 @@ msgid "On a podcast I listen to"
 msgstr "Em um podcast que eu ouço"
 
 #: src/user/adSet/AdSetList.tsx:83
-#: src/user/campaignList/CampaignList.tsx:196
+#: src/user/campaignList/CampaignList.tsx:197
 msgid "On/Off"
 msgstr "Ligado/Desligado"
 
@@ -1324,8 +1323,12 @@ msgid "Once confirmed, your organization’s keypair will be replaced with the n
 msgstr "Após a confirmação, o par de chaves da sua organização será substituído por um novo."
 
 #: src/auth/registration/AccountChoice.tsx:79
-msgid "or <0>contact us</0> for premium ad placements"
-msgstr "ou <0>entre em contato conosco</0> para posicionar anúncios premium"
+msgid "or <0>contact us</0> for New Tab Takeover campaigns"
+msgstr ""
+
+#: src/auth/registration/AccountChoice.tsx:79
+#~ msgid "or <0>contact us</0> for premium ad placements"
+#~ msgstr "ou <0>entre em contato conosco</0> para posicionar anúncios premium"
 
 #: src/auth/views/MagicLink.tsx:100
 msgid "or sign in using a password"
@@ -1411,7 +1414,7 @@ msgstr "Por favor, insira um endereço de e-mail válido"
 msgid "Please enter a valid URL, for example https://brave.com"
 msgstr "Por favor, insira uma URL válida, por exemplo https://brave.com"
 
-#: src/validation/CampaignSchema.tsx:137
+#: src/validation/CampaignSchema.tsx:136
 msgid "Please enter a valid URL, for example https://brave.com/product/*"
 msgstr "Por favor, insira uma URL válida, por exemplo https://brave.com/product/*"
 
@@ -1505,7 +1508,7 @@ msgstr "Privacidade avançada"
 msgid "Private Key"
 msgstr "Chave Privada"
 
-#: src/user/views/user/search/SetupProgress.tsx:44
+#: src/user/views/user/search/SetupProgress.tsx:43
 msgid "Proceed"
 msgstr ""
 
@@ -1565,7 +1568,7 @@ msgstr "Voltar ao dashboard"
 msgid "Review"
 msgstr "Revisão"
 
-#: src/user/views/user/search/SetupProgress.tsx:40
+#: src/user/views/user/search/SetupProgress.tsx:39
 msgid "Review ads"
 msgstr ""
 
@@ -1593,12 +1596,12 @@ msgstr "Salvando..."
 msgid "Search ads"
 msgstr "Anúncios de pesquisa"
 
-#: src/user/library/index.ts:251
+#: src/user/library/index.ts:258
 #: src/util/campaign.ts:10
 msgid "Search homepage"
 msgstr "Página inicial de pesquisa"
 
-#: src/user/library/index.ts:250
+#: src/user/library/index.ts:257
 #: src/util/campaign.ts:9
 msgid "Search keyword"
 msgstr "Palavra-chave de busca"
@@ -1620,7 +1623,7 @@ msgstr "Selecione uma campanha para editar"
 msgid "Select Organization"
 msgstr "Selecione a Organização"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:31
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:32
 msgid "Select the ads you would like to include in this ad set. Only checked ads are included."
 msgstr "Selecione os anúncios que deseja incluir neste conjunto de anúncios. Apenas os anúncios marcados com \"check\" serão incluídos."
 
@@ -1629,7 +1632,6 @@ msgid "Select the audience segments to target"
 msgstr "Selecione os segmentos de público-alvo"
 
 #: src/components/Location/LocationPicker.tsx:51
-#: src/user/views/adsManager/views/advanced/components/campaign/fields/LocationField.tsx:10
 msgid "Select the geographic regions where your ads will be shown."
 msgstr "Selecione as regiões geográficas onde seus anúncios serão exibidos."
 
@@ -1645,7 +1647,7 @@ msgstr "Selecione as plataformas para direcionar"
 msgid "Selected ads"
 msgstr ""
 
-#: src/user/views/user/search/SetupProgress.tsx:29
+#: src/user/views/user/search/SetupProgress.tsx:28
 msgid "Setup Progress"
 msgstr ""
 
@@ -1668,7 +1670,7 @@ msgstr "Taxa de visita ao site"
 #: src/user/analytics/analyticsOverview/components/BasePieChart.tsx:49
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:45
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:162
-#: src/user/campaignList/CampaignList.tsx:145
+#: src/user/campaignList/CampaignList.tsx:146
 msgid "Site visits"
 msgstr "Visitas ao site"
 
@@ -1689,16 +1691,16 @@ msgstr "Algo deu errado."
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:168
 #: src/user/analytics/analyticsOverview/reports/os/components/OsPieChart.tsx:40
 #: src/user/analytics/search/metrics.ts:63
-#: src/user/campaignList/CampaignList.tsx:105
+#: src/user/campaignList/CampaignList.tsx:106
 #: src/user/views/user/AdDetailTable.tsx:30
 msgid "Spend"
 msgstr "Gasto"
 
-#: src/components/Creatives/SearchPreview.tsx:226
+#: src/components/Creatives/SearchPreview.tsx:247
 msgid "Sponsored"
 msgstr ""
 
-#: src/user/campaignList/CampaignList.tsx:175
+#: src/user/campaignList/CampaignList.tsx:176
 msgid "Start"
 msgstr "Iniciar"
 
@@ -1733,7 +1735,7 @@ msgstr "Estado"
 #: src/components/Creatives/CreativeCampaigns.tsx:48
 #: src/user/adSet/AdSetList.tsx:98
 #: src/user/analytics/search/AdSetBreakdown.tsx:73
-#: src/user/campaignList/CampaignList.tsx:85
+#: src/user/campaignList/CampaignList.tsx:86
 msgid "Status"
 msgstr "Status"
 
@@ -1747,7 +1749,7 @@ msgstr "O endereço é obrigatório"
 
 #: src/auth/registration/BrowserRegister.tsx:37
 #: src/auth/registration/SearchRegister.tsx:41
-#: src/user/views/user/search/SetupProgress.tsx:57
+#: src/user/views/user/search/SetupProgress.tsx:56
 msgid "Submit"
 msgstr "Enviar"
 

--- a/src/locales/test.po
+++ b/src/locales/test.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "{adFormatName} are not available for self-managed campaigns. Please contact sales to inquire."
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:188
+#: src/validation/CampaignSchema.tsx:187
 msgid "{billingType} price must be {price} or higher"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgid "Ad format"
 msgstr ""
 
 #: src/components/Creatives/CreativeList.tsx:65
-#: src/user/campaignList/CampaignList.tsx:76
+#: src/user/campaignList/CampaignList.tsx:77
 msgid "Ad Format"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Ad Sets"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:159
+#: src/validation/CampaignSchema.tsx:158
 msgid "Ad sets must have at least one ad"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Ad type must be notification or news"
 msgstr ""
 
-#: src/user/ads/AdsExistingAd.tsx:87
+#: src/user/ads/AdsExistingAd.tsx:76
 msgid "Add an existing ad"
 msgstr ""
 
@@ -178,15 +178,15 @@ msgstr ""
 #: src/components/AppBar/LandingPageAppBar.tsx:85
 #: src/components/Assets/AdvertiserAssets.tsx:33
 #: src/components/Creatives/CreativeList.tsx:102
-#: src/components/Creatives/CreativeSpecificPreview.tsx:52
-#: src/components/Creatives/CreativeSpecificPreview.tsx:63
+#: src/components/Creatives/CreativeSpecificPreview.tsx:54
+#: src/components/Creatives/CreativeSpecificPreview.tsx:65
 #: src/components/Drawer/MiniSideBar.tsx:32
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:29
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:30
 #: src/user/views/user/CampaignDetails.tsx:41
 msgid "Ads"
 msgstr ""
 
-#: src/user/ads/AdsExistingAd.tsx:91
+#: src/user/ads/AdsExistingAd.tsx:80
 msgid "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Advertiser Name"
 msgstr ""
 
-#: src/user/views/user/search/SetupProgress.tsx:35
+#: src/user/views/user/search/SetupProgress.tsx:34
 msgid "Advertiser profile"
 msgstr ""
 
@@ -239,14 +239,14 @@ msgid "At a marketing/media conference"
 msgstr ""
 
 #: src/validation/CampaignSchema.tsx:109
-msgid "At least one audience must be targeted"
-msgstr ""
+#~ msgid "At least one audience must be targeted"
+#~ msgstr ""
 
 #: src/validation/CampaignSchema.tsx:82
 msgid "At least one country must be targeted"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:118
+#: src/validation/CampaignSchema.tsx:117
 msgid "At least one platform must be targeted"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgid "Automatic interest targeting"
 msgstr ""
 
 #: src/components/Steps/NextAndBack.tsx:33
-#: src/user/views/user/search/SetupProgress.tsx:54
+#: src/user/views/user/search/SetupProgress.tsx:53
 msgid "Back"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgid "Browser-based delivery offers a new way to reach audiences on the Web."
 msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/LiveFeed.tsx:52
-#: src/user/campaignList/CampaignList.tsx:96
+#: src/user/campaignList/CampaignList.tsx:97
 msgid "Budget"
 msgstr ""
 
@@ -457,7 +457,7 @@ msgstr ""
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:35
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:164
 #: src/user/analytics/search/metrics.ts:46
-#: src/user/campaignList/CampaignList.tsx:132
+#: src/user/campaignList/CampaignList.tsx:133
 #: src/user/views/user/AdDetailTable.tsx:59
 msgid "Clicks"
 msgstr ""
@@ -535,23 +535,23 @@ msgstr ""
 msgid "Conversion Type"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:152
+#: src/validation/CampaignSchema.tsx:151
 msgid "Conversion type must be Post Click or Post View"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:154
+#: src/validation/CampaignSchema.tsx:153
 msgid "Conversion type required."
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:141
+#: src/validation/CampaignSchema.tsx:140
 msgid "Conversion URL must end in trailing asterisk (*)"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:129
+#: src/validation/CampaignSchema.tsx:128
 msgid "Conversion URL must not contain any whitespace"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:133
+#: src/validation/CampaignSchema.tsx:132
 msgid "Conversion URL must start with https://"
 msgstr ""
 
@@ -559,7 +559,7 @@ msgstr ""
 msgid "Conversion URL Pattern"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:126
+#: src/validation/CampaignSchema.tsx:125
 msgid "Conversion URL required."
 msgstr ""
 
@@ -678,7 +678,6 @@ msgid "CTR"
 msgstr ""
 
 #: src/auth/views/LandingPage.tsx:65
-#: src/components/Button/ContainedDashboardButton.tsx:8
 #: src/components/Button/DashboardButton.tsx:14
 msgid "Dashboard"
 msgstr ""
@@ -803,7 +802,7 @@ msgstr ""
 msgid "Email address is required"
 msgstr ""
 
-#: src/user/campaignList/CampaignList.tsx:184
+#: src/user/campaignList/CampaignList.tsx:185
 msgid "End"
 msgstr ""
 
@@ -863,11 +862,11 @@ msgstr ""
 msgid "File upload complete for \"{fileName}\""
 msgstr ""
 
-#: src/user/ads/AdsExistingAd.tsx:101
+#: src/user/ads/AdsExistingAd.tsx:90
 msgid "Filter ads by name..."
 msgstr ""
 
-#: src/user/views/user/search/SetupProgress.tsx:50
+#: src/user/views/user/search/SetupProgress.tsx:49
 msgid "Finalize & submit"
 msgstr ""
 
@@ -1011,7 +1010,7 @@ msgstr ""
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:30
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:154
 #: src/user/analytics/search/metrics.ts:38
-#: src/user/campaignList/CampaignList.tsx:118
+#: src/user/campaignList/CampaignList.tsx:119
 #: src/user/views/user/AdDetailTable.tsx:47
 msgid "Impressions"
 msgstr ""
@@ -1122,8 +1121,8 @@ msgid "Limited time only. Available to new advertisers, and those who ran campai
 msgstr ""
 
 #: src/user/views/adsManager/views/advanced/components/campaign/fields/LocationField.tsx:8
-msgid "Location"
-msgstr ""
+#~ msgid "Location"
+#~ msgstr ""
 
 #: src/user/views/adsManager/views/advanced/components/review/components/CampaignReview.tsx:67
 msgid "Locations"
@@ -1218,8 +1217,8 @@ msgstr ""
 msgid "New Keypair"
 msgstr ""
 
-#: src/user/campaignList/CampaignList.tsx:262
-#: src/user/library/index.ts:248
+#: src/user/campaignList/CampaignList.tsx:263
+#: src/user/library/index.ts:255
 #: src/util/campaign.ts:7
 msgid "New tab takeover"
 msgstr ""
@@ -1228,7 +1227,7 @@ msgstr ""
 msgid "New tab takeovers"
 msgstr ""
 
-#: src/user/library/index.ts:249
+#: src/user/library/index.ts:256
 #: src/util/campaign.ts:8
 msgid "Newsfeed"
 msgstr ""
@@ -1251,7 +1250,7 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:180
+#: src/validation/CampaignSchema.tsx:179
 msgid "No {billingType} pricing available for {label}, contact selfserve@brave.com for help"
 msgstr ""
 
@@ -1263,7 +1262,7 @@ msgstr ""
 msgid "No file result"
 msgstr ""
 
-#: src/user/ads/AdsExistingAd.tsx:78
+#: src/user/ads/AdsExistingAd.tsx:67
 msgid "No previous ads available"
 msgstr ""
 
@@ -1280,7 +1279,7 @@ msgstr ""
 msgid "Notes"
 msgstr ""
 
-#: src/user/library/index.ts:247
+#: src/user/library/index.ts:254
 #: src/util/campaign.ts:6
 msgid "Notification"
 msgstr ""
@@ -1299,11 +1298,11 @@ msgstr ""
 msgid "Observation Window"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:146
+#: src/validation/CampaignSchema.tsx:145
 msgid "Observation window must be 1, 7, or 30 days."
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:148
+#: src/validation/CampaignSchema.tsx:147
 msgid "Observation window required."
 msgstr ""
 
@@ -1316,7 +1315,7 @@ msgid "On a podcast I listen to"
 msgstr ""
 
 #: src/user/adSet/AdSetList.tsx:83
-#: src/user/campaignList/CampaignList.tsx:196
+#: src/user/campaignList/CampaignList.tsx:197
 msgid "On/Off"
 msgstr ""
 
@@ -1325,8 +1324,12 @@ msgid "Once confirmed, your organization’s keypair will be replaced with the n
 msgstr ""
 
 #: src/auth/registration/AccountChoice.tsx:79
-msgid "or <0>contact us</0> for premium ad placements"
+msgid "or <0>contact us</0> for New Tab Takeover campaigns"
 msgstr ""
+
+#: src/auth/registration/AccountChoice.tsx:79
+#~ msgid "or <0>contact us</0> for premium ad placements"
+#~ msgstr ""
 
 #: src/auth/views/MagicLink.tsx:100
 msgid "or sign in using a password"
@@ -1412,7 +1415,7 @@ msgstr ""
 msgid "Please enter a valid URL, for example https://brave.com"
 msgstr ""
 
-#: src/validation/CampaignSchema.tsx:137
+#: src/validation/CampaignSchema.tsx:136
 msgid "Please enter a valid URL, for example https://brave.com/product/*"
 msgstr ""
 
@@ -1506,7 +1509,7 @@ msgstr ""
 msgid "Private Key"
 msgstr ""
 
-#: src/user/views/user/search/SetupProgress.tsx:44
+#: src/user/views/user/search/SetupProgress.tsx:43
 msgid "Proceed"
 msgstr ""
 
@@ -1566,7 +1569,7 @@ msgstr ""
 msgid "Review"
 msgstr ""
 
-#: src/user/views/user/search/SetupProgress.tsx:40
+#: src/user/views/user/search/SetupProgress.tsx:39
 msgid "Review ads"
 msgstr ""
 
@@ -1594,12 +1597,12 @@ msgstr ""
 msgid "Search ads"
 msgstr ""
 
-#: src/user/library/index.ts:251
+#: src/user/library/index.ts:258
 #: src/util/campaign.ts:10
 msgid "Search homepage"
 msgstr ""
 
-#: src/user/library/index.ts:250
+#: src/user/library/index.ts:257
 #: src/util/campaign.ts:9
 msgid "Search keyword"
 msgstr ""
@@ -1621,7 +1624,7 @@ msgstr ""
 msgid "Select Organization"
 msgstr ""
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:31
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/AdSetAds.tsx:32
 msgid "Select the ads you would like to include in this ad set. Only checked ads are included."
 msgstr ""
 
@@ -1630,7 +1633,6 @@ msgid "Select the audience segments to target"
 msgstr ""
 
 #: src/components/Location/LocationPicker.tsx:51
-#: src/user/views/adsManager/views/advanced/components/campaign/fields/LocationField.tsx:10
 msgid "Select the geographic regions where your ads will be shown."
 msgstr ""
 
@@ -1646,7 +1648,7 @@ msgstr ""
 msgid "Selected ads"
 msgstr ""
 
-#: src/user/views/user/search/SetupProgress.tsx:29
+#: src/user/views/user/search/SetupProgress.tsx:28
 msgid "Setup Progress"
 msgstr ""
 
@@ -1669,7 +1671,7 @@ msgstr ""
 #: src/user/analytics/analyticsOverview/components/BasePieChart.tsx:49
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:45
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:162
-#: src/user/campaignList/CampaignList.tsx:145
+#: src/user/campaignList/CampaignList.tsx:146
 msgid "Site visits"
 msgstr ""
 
@@ -1690,16 +1692,16 @@ msgstr ""
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:168
 #: src/user/analytics/analyticsOverview/reports/os/components/OsPieChart.tsx:40
 #: src/user/analytics/search/metrics.ts:63
-#: src/user/campaignList/CampaignList.tsx:105
+#: src/user/campaignList/CampaignList.tsx:106
 #: src/user/views/user/AdDetailTable.tsx:30
 msgid "Spend"
 msgstr ""
 
-#: src/components/Creatives/SearchPreview.tsx:226
+#: src/components/Creatives/SearchPreview.tsx:247
 msgid "Sponsored"
 msgstr ""
 
-#: src/user/campaignList/CampaignList.tsx:175
+#: src/user/campaignList/CampaignList.tsx:176
 msgid "Start"
 msgstr ""
 
@@ -1734,7 +1736,7 @@ msgstr ""
 #: src/components/Creatives/CreativeCampaigns.tsx:48
 #: src/user/adSet/AdSetList.tsx:98
 #: src/user/analytics/search/AdSetBreakdown.tsx:73
-#: src/user/campaignList/CampaignList.tsx:85
+#: src/user/campaignList/CampaignList.tsx:86
 msgid "Status"
 msgstr ""
 
@@ -1748,7 +1750,7 @@ msgstr ""
 
 #: src/auth/registration/BrowserRegister.tsx:37
 #: src/auth/registration/SearchRegister.tsx:41
-#: src/user/views/user/search/SetupProgress.tsx:57
+#: src/user/views/user/search/SetupProgress.tsx:56
 msgid "Submit"
 msgstr ""
 


### PR DESCRIPTION
None of our ad formats are sub-premium, so this wording is misleading.

<img width="879" alt="Screenshot 2024-05-22 at 12 04 22" src="https://github.com/brave/ads-ui/assets/51444/96b60380-4916-45f8-8b79-ad14af4c0fa2">
