### PR TITLE
fix: add extra spacing at top of screen

### DIFF
--- a/src/auth/views/LandingPage.tsx
+++ b/src/auth/views/LandingPage.tsx
@@ -18,6 +18,7 @@ export function LandingPage() {
     <Background>
       <LandingPageAppBar />
       <Toolbar />
+      <Toolbar />
       <Box width="100%">
         <Box display="flex" justifyContent="center" p={1}>
           <GetStartedLandingPage />

--- a/src/auth/views/LandingPage.tsx
+++ b/src/auth/views/LandingPage.tsx
@@ -17,8 +17,7 @@ export function LandingPage() {
   return (
     <Background>
       <LandingPageAppBar />
-      <Toolbar />
-      <Toolbar />
+      <Toolbar sx={{ mb: 8 }} />
       <Box width="100%">
         <Box display="flex" justifyContent="center" p={1}>
           <GetStartedLandingPage />


### PR DESCRIPTION
Adds extra spacing at top of screen

---

![Screen Shot 2024-06-03 at 11 39 12 AM](https://github.com/brave/ads-ui/assets/48930920/9f3e9a5b-e263-48fd-bc07-3d61789e4698)
