### PR TITLE
feat: add a dismissible conversion change warning

### DIFF
--- a/src/components/Conversion/ConversionDisplay.tsx
+++ b/src/components/Conversion/ConversionDisplay.tsx
@@ -43,19 +43,14 @@ export function ConversionDisplay({ conversions, convErrors }: Props) {
       {conversions.map((c, idx) => (
         <div key={idx}>
           <ReviewField
-            caption={msg`Conversion Type`}
-            value={c.type}
-            error={extractConversionError(idx, "type")}
-          />
-          <ReviewField
-            caption={msg`Observation Window`}
-            value={`${c.observationWindow} days`}
-            error={extractConversionError(idx, "observationWindow")}
-          />
-          <ReviewField
             caption={msg`Conversion URL Pattern`}
             value={c.urlPattern}
             error={extractConversionError(idx, "urlPattern")}
+          />
+          <ReviewField
+            caption={msg`Conversion Observation Window`}
+            value={`${c.observationWindow} days`}
+            error={extractConversionError(idx, "observationWindow")}
           />
         </div>
       ))}

--- a/src/components/Conversion/ConversionFields.tsx
+++ b/src/components/Conversion/ConversionFields.tsx
@@ -1,7 +1,8 @@
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { FormikRadioControl, FormikTextField } from "@/form/FormikHelpers";
-import { msg } from "@lingui/macro";
+import { msg, Trans } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
+import { LearnMoreButton } from "@/components/Button/LearnMoreButton";
 
 interface Props {
   name: string;
@@ -31,7 +32,15 @@ export const ConversionFields = ({ name }: Props) => {
             { value: 7, label: _(msg`7 Days`) },
             { value: 30, label: _(msg`30 Days`) },
           ]}
-          helperText={_(msg`Count conversions within X days of an impression`)}
+          helperText={
+            <Typography variant="body2" sx={{ mb: 2 }}>
+              <Trans>
+                Define the number of days Brave will observe conversions and
+                attribute them to the campaign.
+              </Trans>{" "}
+              <LearnMoreButton helpSection="campaign-performance/reporting/#advanced-controls-for-attribution" />
+            </Typography>
+          }
         />
       </Box>
     </>

--- a/src/components/Conversion/ConversionFields.tsx
+++ b/src/components/Conversion/ConversionFields.tsx
@@ -1,6 +1,6 @@
 import { Box } from "@mui/material";
 import { FormikRadioControl, FormikTextField } from "@/form/FormikHelpers";
-import { msg, Trans } from "@lingui/macro";
+import { msg } from "@lingui/macro";
 import { useLingui } from "@lingui/react";
 
 interface Props {
@@ -12,26 +12,6 @@ export const ConversionFields = ({ name }: Props) => {
 
   return (
     <>
-      <FormikRadioControl
-        name={`${name}.type`}
-        label={_(msg`Type`)}
-        options={[
-          { value: "postview", label: _(msg`Post-View`) },
-          { value: "postclick", label: _(msg`Post-Click`) },
-        ]}
-        helperText={
-          <>
-            <Trans>
-              Post-View: Viewed ad and converted by visiting site on their own.
-            </Trans>
-            <br />
-            <Trans>
-              Post-Click: Viewed ad and converted by clicking its link
-            </Trans>
-          </>
-        }
-      />
-
       <Box>
         <FormikTextField
           name={`${name}.urlPattern`}

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -49,11 +49,11 @@ msgstr "*Limited time only. Available to new advertisers, and those who ran camp
 msgid "+{count} more"
 msgstr "+{count} more"
 
-#: src/components/Conversion/ConversionFields.tsx:50
+#: src/components/Conversion/ConversionFields.tsx:30
 msgid "1 Day"
 msgstr "1 Day"
 
-#: src/components/Conversion/ConversionFields.tsx:52
+#: src/components/Conversion/ConversionFields.tsx:32
 msgid "30 Days"
 msgstr "30 Days"
 
@@ -61,7 +61,7 @@ msgstr "30 Days"
 msgid "401 Forbidden"
 msgstr "401 Forbidden"
 
-#: src/components/Conversion/ConversionFields.tsx:51
+#: src/components/Conversion/ConversionFields.tsx:31
 msgid "7 Days"
 msgstr "7 Days"
 
@@ -83,7 +83,7 @@ msgstr "About Brave Ads"
 
 #: src/components/Drawer/MiniSideBar.tsx:57
 #: src/components/Navigation/AccountMenu.tsx:36
-#: src/components/Navigation/AccountMenu.tsx:97
+#: src/components/Navigation/AccountMenu.tsx:95
 #: src/user/settings/Settings.tsx:49
 msgid "Account"
 msgstr "Account"
@@ -194,7 +194,7 @@ msgstr "Ad type must be notification or news"
 msgid "Add an existing ad"
 msgstr "Add an existing ad"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:44
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:45
 msgid "Add Conversion tracking"
 msgstr "Add Conversion tracking"
 
@@ -518,7 +518,7 @@ msgstr "Campaign Summary"
 
 #: src/components/Creatives/CreativeCampaigns.tsx:40
 #: src/components/Drawer/MiniSideBar.tsx:22
-#: src/user/views/user/CampaignView.tsx:42
+#: src/user/views/user/CampaignView.tsx:45
 msgid "Campaigns"
 msgstr "Campaigns"
 
@@ -679,9 +679,13 @@ msgid "Continue"
 msgstr "Continue"
 
 #: src/components/Conversion/ConversionDisplay.tsx:18
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:20
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:21
 msgid "Conversion"
 msgstr "Conversion"
+
+#: src/components/Conversion/ConversionDisplay.tsx:51
+msgid "Conversion Observation Window"
+msgstr "Conversion Observation Window"
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:70
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:150
@@ -692,9 +696,17 @@ msgstr "Conversion"
 msgid "Conversion Rate"
 msgstr "Conversion Rate"
 
+#: src/user/views/user/ConversionAlert.tsx:12
+msgid "Conversion reporting change"
+msgstr "Conversion reporting change"
+
+#: src/user/views/user/ConversionAlert.tsx:14
+msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+msgstr "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+
 #: src/components/Conversion/ConversionDisplay.tsx:46
-msgid "Conversion Type"
-msgstr "Conversion Type"
+#~ msgid "Conversion Type"
+#~ msgstr "Conversion Type"
 
 #: src/validation/CampaignSchema.tsx:151
 msgid "Conversion type must be Post Click or Post View"
@@ -716,7 +728,7 @@ msgstr "Conversion URL must not contain any whitespace"
 msgid "Conversion URL must start with https://"
 msgstr "Conversion URL must start with https://"
 
-#: src/components/Conversion/ConversionDisplay.tsx:56
+#: src/components/Conversion/ConversionDisplay.tsx:46
 msgid "Conversion URL Pattern"
 msgstr "Conversion URL Pattern"
 
@@ -744,7 +756,7 @@ msgstr "Cost per click"
 msgid "Could not logout at this time. Please try again later."
 msgstr "Could not logout at this time. Please try again later."
 
-#: src/components/Conversion/ConversionFields.tsx:54
+#: src/components/Conversion/ConversionFields.tsx:34
 msgid "Count conversions within X days of an impression"
 msgstr "Count conversions within X days of an impression"
 
@@ -1008,7 +1020,7 @@ msgstr "End date must be after start date"
 msgid "End Time"
 msgstr "End Time"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:26
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
 msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
 msgstr "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
 
@@ -1439,7 +1451,7 @@ msgstr "Log into your Brave Ads account"
 msgid "Logging in"
 msgstr "Logging in"
 
-#: src/components/Navigation/AccountMenu.tsx:136
+#: src/components/Navigation/AccountMenu.tsx:134
 msgid "Logout"
 msgstr "Logout"
 
@@ -1607,8 +1619,7 @@ msgstr "Notification ad"
 msgid "Notification ads"
 msgstr "Notification ads"
 
-#: src/components/Conversion/ConversionDisplay.tsx:51
-#: src/components/Conversion/ConversionFields.tsx:48
+#: src/components/Conversion/ConversionFields.tsx:28
 msgid "Observation Window"
 msgstr "Observation Window"
 
@@ -1680,7 +1691,7 @@ msgstr "OS"
 msgid "Other (please specify)"
 msgstr "Other (please specify)"
 
-#: src/components/Navigation/AccountMenu.tsx:106
+#: src/components/Navigation/AccountMenu.tsx:104
 msgid "Other accounts"
 msgstr "Other accounts"
 
@@ -1792,20 +1803,20 @@ msgid "Please specify how you heard about Brave Ads"
 msgstr "Please specify how you heard about Brave Ads"
 
 #: src/components/Conversion/ConversionFields.tsx:20
-msgid "Post-Click"
-msgstr "Post-Click"
+#~ msgid "Post-Click"
+#~ msgstr "Post-Click"
 
 #: src/components/Conversion/ConversionFields.tsx:28
-msgid "Post-Click: Viewed ad and converted by clicking its link"
-msgstr "Post-Click: Viewed ad and converted by clicking its link"
+#~ msgid "Post-Click: Viewed ad and converted by clicking its link"
+#~ msgstr "Post-Click: Viewed ad and converted by clicking its link"
 
 #: src/components/Conversion/ConversionFields.tsx:19
-msgid "Post-View"
-msgstr "Post-View"
+#~ msgid "Post-View"
+#~ msgstr "Post-View"
 
 #: src/components/Conversion/ConversionFields.tsx:24
-msgid "Post-View: Viewed ad and converted by visiting site on their own."
-msgstr "Post-View: Viewed ad and converted by visiting site on their own."
+#~ msgid "Post-View: Viewed ad and converted by visiting site on their own."
+#~ msgstr "Post-View: Viewed ad and converted by visiting site on their own."
 
 #: src/auth/views/MobileAdsBenefits.tsx:22
 #~ msgid "Powerful ad formats"
@@ -1913,9 +1924,13 @@ msgstr "Ready to reach your first million users? Start your first campaign today
 msgid "Remove"
 msgstr "Remove"
 
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:68
+msgid "Remove Conversion tracking"
+msgstr "Remove Conversion tracking"
+
 #: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:54
-msgid "Remove Conversion Tracking"
-msgstr "Remove Conversion Tracking"
+#~ msgid "Remove Conversion Tracking"
+#~ msgstr "Remove Conversion Tracking"
 
 #: src/auth/components/AdvertiserAgreed.tsx:14
 #~ msgid "Reporting"
@@ -2378,8 +2393,8 @@ msgstr "Try a free one-month test to see how Brave Search Ads perform for your b
 #~ msgstr "Try again"
 
 #: src/components/Conversion/ConversionFields.tsx:17
-msgid "Type"
-msgstr "Type"
+#~ msgid "Type"
+#~ msgstr "Type"
 
 #: src/components/Campaigns/CloneCampaign.tsx:43
 msgid "Unable to clone campaign"
@@ -2437,7 +2452,7 @@ msgstr "Unable to register your organization at this time. Please try again late
 #~ msgid "Unable to retrieve ad sets or ads for Campaign."
 #~ msgstr "Unable to retrieve ad sets or ads for Campaign."
 
-#: src/user/views/user/CampaignView.tsx:34
+#: src/user/views/user/CampaignView.tsx:35
 msgid "Unable to retrieve Campaign data."
 msgstr "Unable to retrieve Campaign data."
 
@@ -2528,11 +2543,11 @@ msgstr "URL must not contain any whitespace"
 msgid "URL must start with https://"
 msgstr "URL must start with https://"
 
-#: src/components/Conversion/ConversionFields.tsx:38
+#: src/components/Conversion/ConversionFields.tsx:18
 msgid "URL Pattern"
 msgstr "URL Pattern"
 
-#: src/components/Conversion/ConversionFields.tsx:40
+#: src/components/Conversion/ConversionFields.tsx:20
 msgid "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 msgstr "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -49,11 +49,11 @@ msgstr "*Limited time only. Available to new advertisers, and those who ran camp
 msgid "+{count} more"
 msgstr "+{count} more"
 
-#: src/components/Conversion/ConversionFields.tsx:30
+#: src/components/Conversion/ConversionFields.tsx:31
 msgid "1 Day"
 msgstr "1 Day"
 
-#: src/components/Conversion/ConversionFields.tsx:32
+#: src/components/Conversion/ConversionFields.tsx:33
 msgid "30 Days"
 msgstr "30 Days"
 
@@ -61,7 +61,7 @@ msgstr "30 Days"
 msgid "401 Forbidden"
 msgstr "401 Forbidden"
 
-#: src/components/Conversion/ConversionFields.tsx:31
+#: src/components/Conversion/ConversionFields.tsx:32
 msgid "7 Days"
 msgstr "7 Days"
 
@@ -219,6 +219,10 @@ msgstr "Ads"
 #: src/user/ads/AdsExistingAd.tsx:80
 msgid "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
 msgstr "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
+
+#: src/user/views/user/ConversionAlert.tsx:36
+msgid "Ads Help Center"
+msgstr "Ads Help Center"
 
 #: src/routes/campaigns/analytics/breakdowns.tsx:135
 #~ msgid "AdSet Performance"
@@ -701,8 +705,16 @@ msgid "Conversion reporting change"
 msgstr "Conversion reporting change"
 
 #: src/user/views/user/ConversionAlert.tsx:14
-msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
-msgstr "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+#~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at in the <0/>"
+#~ msgstr "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at in the <0/>"
+
+#: src/user/views/user/ConversionAlert.tsx:14
+msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
+msgstr "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
+
+#: src/user/views/user/ConversionAlert.tsx:14
+#~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+#~ msgstr "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
 
 #: src/components/Conversion/ConversionDisplay.tsx:46
 #~ msgid "Conversion Type"
@@ -757,8 +769,8 @@ msgid "Could not logout at this time. Please try again later."
 msgstr "Could not logout at this time. Please try again later."
 
 #: src/components/Conversion/ConversionFields.tsx:34
-msgid "Count conversions within X days of an impression"
-msgstr "Count conversions within X days of an impression"
+#~ msgid "Count conversions within X days of an impression"
+#~ msgstr "Count conversions within X days of an impression"
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:46
 #~ msgid "Counted if the user clicks an ad and spends at least 10 seconds on the advertiser's website, with the website open in an active browser tab. The 10 seconds must be spent on the site after arriving by clicking the ad link, and the tab must remain open and active the entire time for the visit to count."
@@ -889,6 +901,10 @@ msgstr "Decrypt Conversion Data?"
 #: src/user/views/adsManager/views/advanced/components/campaign/CampaignSettings.tsx:27
 msgid "Define how you want your campaign to run."
 msgstr "Define how you want your campaign to run."
+
+#: src/components/Conversion/ConversionFields.tsx:37
+msgid "Define the number of days Brave will observe conversions and attribute them to the campaign."
+msgstr "Define the number of days Brave will observe conversions and attribute them to the campaign."
 
 #: src/user/ads/AdList.tsx:66
 #~ msgid "DELETED"
@@ -1021,8 +1037,12 @@ msgid "End Time"
 msgstr "End Time"
 
 #: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
-msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
-msgstr "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
+msgid "Enter a URL that indicates a desired action you want to measure, like a subscription or purchase confirmation page. Brave will count unique visits to that page as conversions if a user has seen or clicked your ad."
+msgstr "Enter a URL that indicates a desired action you want to measure, like a subscription or purchase confirmation page. Brave will count unique visits to that page as conversions if a user has seen or clicked your ad."
+
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
+#~ msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
+#~ msgstr "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
 
 #: src/auth/components/AdvertiserDetailsForm.tsx:118
 msgid "Enter Ads Manager"
@@ -1619,7 +1639,7 @@ msgstr "Notification ad"
 msgid "Notification ads"
 msgstr "Notification ads"
 
-#: src/components/Conversion/ConversionFields.tsx:28
+#: src/components/Conversion/ConversionFields.tsx:29
 msgid "Observation Window"
 msgstr "Observation Window"
 
@@ -2543,11 +2563,11 @@ msgstr "URL must not contain any whitespace"
 msgid "URL must start with https://"
 msgstr "URL must start with https://"
 
-#: src/components/Conversion/ConversionFields.tsx:18
+#: src/components/Conversion/ConversionFields.tsx:19
 msgid "URL Pattern"
 msgstr "URL Pattern"
 
-#: src/components/Conversion/ConversionFields.tsx:20
+#: src/components/Conversion/ConversionFields.tsx:21
 msgid "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 msgstr "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -49,11 +49,11 @@ msgstr ""
 msgid "+{count} more"
 msgstr "+{count} más"
 
-#: src/components/Conversion/ConversionFields.tsx:50
+#: src/components/Conversion/ConversionFields.tsx:30
 msgid "1 Day"
 msgstr "1 día"
 
-#: src/components/Conversion/ConversionFields.tsx:52
+#: src/components/Conversion/ConversionFields.tsx:32
 msgid "30 Days"
 msgstr "30 días "
 
@@ -61,7 +61,7 @@ msgstr "30 días "
 msgid "401 Forbidden"
 msgstr "401 prohibido"
 
-#: src/components/Conversion/ConversionFields.tsx:51
+#: src/components/Conversion/ConversionFields.tsx:31
 msgid "7 Days"
 msgstr "7 días"
 
@@ -79,7 +79,7 @@ msgstr "Acerca de Brave Ads"
 
 #: src/components/Drawer/MiniSideBar.tsx:57
 #: src/components/Navigation/AccountMenu.tsx:36
-#: src/components/Navigation/AccountMenu.tsx:97
+#: src/components/Navigation/AccountMenu.tsx:95
 #: src/user/settings/Settings.tsx:49
 msgid "Account"
 msgstr "Cuenta"
@@ -190,7 +190,7 @@ msgstr "El tipo de anuncio debe ser notificación o noticias"
 msgid "Add an existing ad"
 msgstr "Añadir un anuncio existente"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:44
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:45
 msgid "Add Conversion tracking"
 msgstr "Añadir seguimiento de conversiones"
 
@@ -503,7 +503,7 @@ msgstr ""
 
 #: src/components/Creatives/CreativeCampaigns.tsx:40
 #: src/components/Drawer/MiniSideBar.tsx:22
-#: src/user/views/user/CampaignView.tsx:42
+#: src/user/views/user/CampaignView.tsx:45
 msgid "Campaigns"
 msgstr "Campañas"
 
@@ -659,9 +659,13 @@ msgid "Continue"
 msgstr "Continuar"
 
 #: src/components/Conversion/ConversionDisplay.tsx:18
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:20
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:21
 msgid "Conversion"
 msgstr "Conversión"
+
+#: src/components/Conversion/ConversionDisplay.tsx:51
+msgid "Conversion Observation Window"
+msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:70
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:150
@@ -672,9 +676,17 @@ msgstr "Conversión"
 msgid "Conversion Rate"
 msgstr ""
 
+#: src/user/views/user/ConversionAlert.tsx:12
+msgid "Conversion reporting change"
+msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+msgstr ""
+
 #: src/components/Conversion/ConversionDisplay.tsx:46
-msgid "Conversion Type"
-msgstr "Tipo de conversión"
+#~ msgid "Conversion Type"
+#~ msgstr "Tipo de conversión"
 
 #: src/validation/CampaignSchema.tsx:151
 msgid "Conversion type must be Post Click or Post View"
@@ -696,7 +708,7 @@ msgstr "La URL de conversión no debe contener espacios en blanco"
 msgid "Conversion URL must start with https://"
 msgstr "La URL de conversión debe comenzar con https://"
 
-#: src/components/Conversion/ConversionDisplay.tsx:56
+#: src/components/Conversion/ConversionDisplay.tsx:46
 msgid "Conversion URL Pattern"
 msgstr "Patrón de URL de conversión"
 
@@ -724,7 +736,7 @@ msgstr ""
 msgid "Could not logout at this time. Please try again later."
 msgstr "No se pudo cerrar la sesión en este momento. Por favor, inténtelo de nuevo más tarde."
 
-#: src/components/Conversion/ConversionFields.tsx:54
+#: src/components/Conversion/ConversionFields.tsx:34
 msgid "Count conversions within X days of an impression"
 msgstr "Contar las conversiones en un plazo de X días a partir de una impresión."
 
@@ -987,7 +999,7 @@ msgstr "La fecha de finalización debe ser posterior a la fecha de inicio"
 msgid "End Time"
 msgstr "Hora de finalización"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:26
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
 msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
 msgstr "Introduzca una URL que represente su objetivo de conversión, como una página de pago o de confirmación de suscripción. <0/>Brave contará las visitas únicas a esa página de los usuarios que vieron o hicieron clic en su anuncio."
 
@@ -1407,7 +1419,7 @@ msgstr "Inicie sesión en su cuenta de Brave Ads"
 msgid "Logging in"
 msgstr "Iniciando sesión"
 
-#: src/components/Navigation/AccountMenu.tsx:136
+#: src/components/Navigation/AccountMenu.tsx:134
 msgid "Logout"
 msgstr ""
 
@@ -1572,8 +1584,7 @@ msgstr "Anuncio de notificación"
 msgid "Notification ads"
 msgstr "Anuncios de notificación"
 
-#: src/components/Conversion/ConversionDisplay.tsx:51
-#: src/components/Conversion/ConversionFields.tsx:48
+#: src/components/Conversion/ConversionFields.tsx:28
 msgid "Observation Window"
 msgstr "Ventana de observación"
 
@@ -1644,7 +1655,7 @@ msgstr "Sistema Operativo"
 msgid "Other (please specify)"
 msgstr "Otro (por favor, especifique)"
 
-#: src/components/Navigation/AccountMenu.tsx:106
+#: src/components/Navigation/AccountMenu.tsx:104
 msgid "Other accounts"
 msgstr ""
 
@@ -1754,20 +1765,20 @@ msgid "Please specify how you heard about Brave Ads"
 msgstr "Por favor, especifique cómo se enteró de Brave Ads"
 
 #: src/components/Conversion/ConversionFields.tsx:20
-msgid "Post-Click"
-msgstr "Post-clic"
+#~ msgid "Post-Click"
+#~ msgstr "Post-clic"
 
 #: src/components/Conversion/ConversionFields.tsx:28
-msgid "Post-Click: Viewed ad and converted by clicking its link"
-msgstr "Post-clic: Anuncio visto y convertido al hacer clic en su enlace"
+#~ msgid "Post-Click: Viewed ad and converted by clicking its link"
+#~ msgstr "Post-clic: Anuncio visto y convertido al hacer clic en su enlace"
 
 #: src/components/Conversion/ConversionFields.tsx:19
-msgid "Post-View"
-msgstr "Post-vista"
+#~ msgid "Post-View"
+#~ msgstr "Post-vista"
 
 #: src/components/Conversion/ConversionFields.tsx:24
-msgid "Post-View: Viewed ad and converted by visiting site on their own."
-msgstr "Post-vista: Anuncio visto y convertido al visitar el sitio por su cuenta."
+#~ msgid "Post-View: Viewed ad and converted by visiting site on their own."
+#~ msgstr "Post-vista: Anuncio visto y convertido al visitar el sitio por su cuenta."
 
 #: src/auth/views/MobileAdsBenefits.tsx:22
 #~ msgid "Powerful ad formats"
@@ -1871,9 +1882,13 @@ msgstr ""
 msgid "Remove"
 msgstr "Eliminar"
 
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:68
+msgid "Remove Conversion tracking"
+msgstr ""
+
 #: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:54
-msgid "Remove Conversion Tracking"
-msgstr "Eliminar seguimiento de conversión"
+#~ msgid "Remove Conversion Tracking"
+#~ msgstr "Eliminar seguimiento de conversión"
 
 #: src/user/analytics/analyticsOverview/reports/campaign/EngagementsOverview.tsx:117
 #~ msgid "Reporting not available yet for <0>{campaignName}</0>."
@@ -2300,8 +2315,8 @@ msgstr ""
 #~ msgstr "Inténtelo de nuevo"
 
 #: src/components/Conversion/ConversionFields.tsx:17
-msgid "Type"
-msgstr "Tipo"
+#~ msgid "Type"
+#~ msgstr "Tipo"
 
 #: src/components/Campaigns/CloneCampaign.tsx:43
 msgid "Unable to clone campaign"
@@ -2355,7 +2370,7 @@ msgstr "No se puede registrar su organización en este momento. Por favor, inté
 #~ msgid "Unable to retrieve ad sets or ads for Campaign."
 #~ msgstr "No se pueden recuperar los conjuntos de anuncios ni los anuncios para la campaña."
 
-#: src/user/views/user/CampaignView.tsx:34
+#: src/user/views/user/CampaignView.tsx:35
 msgid "Unable to retrieve Campaign data."
 msgstr "No se pueden recuperar los datos de la campaña."
 
@@ -2446,11 +2461,11 @@ msgstr "La URL no debe contener espacios en blanco"
 msgid "URL must start with https://"
 msgstr "La URL debe comenzar con https://"
 
-#: src/components/Conversion/ConversionFields.tsx:38
+#: src/components/Conversion/ConversionFields.tsx:18
 msgid "URL Pattern"
 msgstr "Patrón de URL"
 
-#: src/components/Conversion/ConversionFields.tsx:40
+#: src/components/Conversion/ConversionFields.tsx:20
 msgid "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 msgstr "La URL debe tener un asterisco al final - Ejemplo: https://brave.com/products/*"
 

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -49,11 +49,11 @@ msgstr ""
 msgid "+{count} more"
 msgstr "+{count} más"
 
-#: src/components/Conversion/ConversionFields.tsx:30
+#: src/components/Conversion/ConversionFields.tsx:31
 msgid "1 Day"
 msgstr "1 día"
 
-#: src/components/Conversion/ConversionFields.tsx:32
+#: src/components/Conversion/ConversionFields.tsx:33
 msgid "30 Days"
 msgstr "30 días "
 
@@ -61,7 +61,7 @@ msgstr "30 días "
 msgid "401 Forbidden"
 msgstr "401 prohibido"
 
-#: src/components/Conversion/ConversionFields.tsx:31
+#: src/components/Conversion/ConversionFields.tsx:32
 msgid "7 Days"
 msgstr "7 días"
 
@@ -215,6 +215,10 @@ msgstr "Anuncios"
 #: src/user/ads/AdsExistingAd.tsx:80
 msgid "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
 msgstr "Los anuncios son bloques de construcción modulares que se pueden combinar con conjuntos de anuncios para crear combinaciones únicas. Los anuncios aprobados anteriormente se mostrarán aquí. Seleccione la casilla situada junto al nombre. Utilice el botón “Completar selección” para finalizar."
+
+#: src/user/views/user/ConversionAlert.tsx:36
+msgid "Ads Help Center"
+msgstr ""
 
 #: src/routes/campaigns/analytics/breakdowns.tsx:135
 #~ msgid "AdSet Performance"
@@ -681,8 +685,16 @@ msgid "Conversion reporting change"
 msgstr ""
 
 #: src/user/views/user/ConversionAlert.tsx:14
-msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+#~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at in the <0/>"
+#~ msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+#~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+#~ msgstr ""
 
 #: src/components/Conversion/ConversionDisplay.tsx:46
 #~ msgid "Conversion Type"
@@ -737,8 +749,8 @@ msgid "Could not logout at this time. Please try again later."
 msgstr "No se pudo cerrar la sesión en este momento. Por favor, inténtelo de nuevo más tarde."
 
 #: src/components/Conversion/ConversionFields.tsx:34
-msgid "Count conversions within X days of an impression"
-msgstr "Contar las conversiones en un plazo de X días a partir de una impresión."
+#~ msgid "Count conversions within X days of an impression"
+#~ msgstr "Contar las conversiones en un plazo de X días a partir de una impresión."
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:46
 #~ msgid "Counted if the user clicks an ad and spends at least 10 seconds on the advertiser's website, with the website open in an active browser tab. The 10 seconds must be spent on the site after arriving by clicking the ad link, and the tab must remain open and active the entire time for the visit to count."
@@ -868,6 +880,10 @@ msgstr "¿Descifrar datos de conversión?"
 #: src/user/views/adsManager/views/advanced/components/campaign/CampaignSettings.tsx:27
 msgid "Define how you want your campaign to run."
 msgstr "Defina cómo quiere que se publique su campaña."
+
+#: src/components/Conversion/ConversionFields.tsx:37
+msgid "Define the number of days Brave will observe conversions and attribute them to the campaign."
+msgstr ""
 
 #: src/user/ads/AdList.tsx:66
 #~ msgid "DELETED"
@@ -1000,8 +1016,12 @@ msgid "End Time"
 msgstr "Hora de finalización"
 
 #: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
-msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
-msgstr "Introduzca una URL que represente su objetivo de conversión, como una página de pago o de confirmación de suscripción. <0/>Brave contará las visitas únicas a esa página de los usuarios que vieron o hicieron clic en su anuncio."
+msgid "Enter a URL that indicates a desired action you want to measure, like a subscription or purchase confirmation page. Brave will count unique visits to that page as conversions if a user has seen or clicked your ad."
+msgstr ""
+
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
+#~ msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
+#~ msgstr "Introduzca una URL que represente su objetivo de conversión, como una página de pago o de confirmación de suscripción. <0/>Brave contará las visitas únicas a esa página de los usuarios que vieron o hicieron clic en su anuncio."
 
 #: src/auth/components/AdvertiserDetailsForm.tsx:118
 msgid "Enter Ads Manager"
@@ -1584,7 +1604,7 @@ msgstr "Anuncio de notificación"
 msgid "Notification ads"
 msgstr "Anuncios de notificación"
 
-#: src/components/Conversion/ConversionFields.tsx:28
+#: src/components/Conversion/ConversionFields.tsx:29
 msgid "Observation Window"
 msgstr "Ventana de observación"
 
@@ -2461,11 +2481,11 @@ msgstr "La URL no debe contener espacios en blanco"
 msgid "URL must start with https://"
 msgstr "La URL debe comenzar con https://"
 
-#: src/components/Conversion/ConversionFields.tsx:18
+#: src/components/Conversion/ConversionFields.tsx:19
 msgid "URL Pattern"
 msgstr "Patrón de URL"
 
-#: src/components/Conversion/ConversionFields.tsx:20
+#: src/components/Conversion/ConversionFields.tsx:21
 msgid "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 msgstr "La URL debe tener un asterisco al final - Ejemplo: https://brave.com/products/*"
 

--- a/src/locales/pt.po
+++ b/src/locales/pt.po
@@ -49,11 +49,11 @@ msgstr ""
 msgid "+{count} more"
 msgstr "+{count} mais"
 
-#: src/components/Conversion/ConversionFields.tsx:30
+#: src/components/Conversion/ConversionFields.tsx:31
 msgid "1 Day"
 msgstr "1 Dia"
 
-#: src/components/Conversion/ConversionFields.tsx:32
+#: src/components/Conversion/ConversionFields.tsx:33
 msgid "30 Days"
 msgstr "30 Dias"
 
@@ -61,7 +61,7 @@ msgstr "30 Dias"
 msgid "401 Forbidden"
 msgstr "401 Proibido"
 
-#: src/components/Conversion/ConversionFields.tsx:31
+#: src/components/Conversion/ConversionFields.tsx:32
 msgid "7 Days"
 msgstr "7 Dias"
 
@@ -215,6 +215,10 @@ msgstr "Anúncios"
 #: src/user/ads/AdsExistingAd.tsx:80
 msgid "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
 msgstr "Anúncios são blocos de construção modulares que podem ser combinados com conjuntos de anúncios para criar combinações únicas. Seus anúncios previamente aprovados serão exibidos aqui. Selecione usando a caixa ao lado do nome. Use o botão \"Seleção Completa\" para concluir."
+
+#: src/user/views/user/ConversionAlert.tsx:36
+msgid "Ads Help Center"
+msgstr ""
 
 #: src/routes/campaigns/analytics/breakdowns.tsx:135
 #~ msgid "AdSet Performance"
@@ -669,8 +673,16 @@ msgid "Conversion reporting change"
 msgstr ""
 
 #: src/user/views/user/ConversionAlert.tsx:14
-msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+#~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at in the <0/>"
+#~ msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+#~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+#~ msgstr ""
 
 #: src/components/Conversion/ConversionDisplay.tsx:46
 #~ msgid "Conversion Type"
@@ -725,8 +737,8 @@ msgid "Could not logout at this time. Please try again later."
 msgstr "Não foi possível fazer logout no momento. Por favor, tente novamente mais tarde."
 
 #: src/components/Conversion/ConversionFields.tsx:34
-msgid "Count conversions within X days of an impression"
-msgstr "Contar conversões dentro de X dias de uma visualização"
+#~ msgid "Count conversions within X days of an impression"
+#~ msgstr "Contar conversões dentro de X dias de uma visualização"
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:46
 #~ msgid "Counted if the user clicks an ad and spends at least 10 seconds on the advertiser's website, with the website open in an active browser tab. The 10 seconds must be spent on the site after arriving by clicking the ad link, and the tab must remain open and active the entire time for the visit to count."
@@ -853,6 +865,10 @@ msgstr "Descriptografar Dados de Conversão?"
 #: src/user/views/adsManager/views/advanced/components/campaign/CampaignSettings.tsx:27
 msgid "Define how you want your campaign to run."
 msgstr "Defina como deseja que sua campanha seja executada."
+
+#: src/components/Conversion/ConversionFields.tsx:37
+msgid "Define the number of days Brave will observe conversions and attribute them to the campaign."
+msgstr ""
 
 #: src/user/ads/AdList.tsx:66
 #~ msgid "DELETED"
@@ -984,8 +1000,12 @@ msgid "End Time"
 msgstr "Horário de término"
 
 #: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
-msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
-msgstr "Digite uma URL que represente o seu objetivo de conversão, como uma página de finalização de compra/checkout ou confirmação de inscrição. <0/>O Brave irá contabilizar as visitas únicas a essa página feitas por usuários que visualizaram ou clicaram no seu anúncio."
+msgid "Enter a URL that indicates a desired action you want to measure, like a subscription or purchase confirmation page. Brave will count unique visits to that page as conversions if a user has seen or clicked your ad."
+msgstr ""
+
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
+#~ msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
+#~ msgstr "Digite uma URL que represente o seu objetivo de conversão, como uma página de finalização de compra/checkout ou confirmação de inscrição. <0/>O Brave irá contabilizar as visitas únicas a essa página feitas por usuários que visualizaram ou clicaram no seu anúncio."
 
 #: src/auth/components/AdvertiserDetailsForm.tsx:118
 msgid "Enter Ads Manager"
@@ -1550,7 +1570,7 @@ msgstr "Anúncio de notificação"
 msgid "Notification ads"
 msgstr "Anúncios de notificação"
 
-#: src/components/Conversion/ConversionFields.tsx:28
+#: src/components/Conversion/ConversionFields.tsx:29
 msgid "Observation Window"
 msgstr "Janela de Observação"
 
@@ -2406,11 +2426,11 @@ msgstr "A URL não deve conter espaços em branco"
 msgid "URL must start with https://"
 msgstr "A URL deve começar com https://"
 
-#: src/components/Conversion/ConversionFields.tsx:18
+#: src/components/Conversion/ConversionFields.tsx:19
 msgid "URL Pattern"
 msgstr "Padrão de URL"
 
-#: src/components/Conversion/ConversionFields.tsx:20
+#: src/components/Conversion/ConversionFields.tsx:21
 msgid "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 msgstr "A URL deve ter um asterisco no final - Exemplo: https://brave.com/produtos/*"
 

--- a/src/locales/pt.po
+++ b/src/locales/pt.po
@@ -49,11 +49,11 @@ msgstr ""
 msgid "+{count} more"
 msgstr "+{count} mais"
 
-#: src/components/Conversion/ConversionFields.tsx:50
+#: src/components/Conversion/ConversionFields.tsx:30
 msgid "1 Day"
 msgstr "1 Dia"
 
-#: src/components/Conversion/ConversionFields.tsx:52
+#: src/components/Conversion/ConversionFields.tsx:32
 msgid "30 Days"
 msgstr "30 Dias"
 
@@ -61,7 +61,7 @@ msgstr "30 Dias"
 msgid "401 Forbidden"
 msgstr "401 Proibido"
 
-#: src/components/Conversion/ConversionFields.tsx:51
+#: src/components/Conversion/ConversionFields.tsx:31
 msgid "7 Days"
 msgstr "7 Dias"
 
@@ -79,7 +79,7 @@ msgstr "Sobre o Brave Ads"
 
 #: src/components/Drawer/MiniSideBar.tsx:57
 #: src/components/Navigation/AccountMenu.tsx:36
-#: src/components/Navigation/AccountMenu.tsx:97
+#: src/components/Navigation/AccountMenu.tsx:95
 #: src/user/settings/Settings.tsx:49
 msgid "Account"
 msgstr "Conta"
@@ -190,7 +190,7 @@ msgstr "O tipo de anúncio deve ser notificação ou notícia"
 msgid "Add an existing ad"
 msgstr "Adicionar um anúncio existente"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:44
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:45
 msgid "Add Conversion tracking"
 msgstr "Adicionar rastreamento de conversão"
 
@@ -494,7 +494,7 @@ msgstr ""
 
 #: src/components/Creatives/CreativeCampaigns.tsx:40
 #: src/components/Drawer/MiniSideBar.tsx:22
-#: src/user/views/user/CampaignView.tsx:42
+#: src/user/views/user/CampaignView.tsx:45
 msgid "Campaigns"
 msgstr "Campanhas"
 
@@ -647,9 +647,13 @@ msgid "Continue"
 msgstr "Continuar"
 
 #: src/components/Conversion/ConversionDisplay.tsx:18
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:20
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:21
 msgid "Conversion"
 msgstr "Conversão"
+
+#: src/components/Conversion/ConversionDisplay.tsx:51
+msgid "Conversion Observation Window"
+msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:70
 #: src/user/analytics/analyticsOverview/lib/overview.library.ts:150
@@ -660,9 +664,17 @@ msgstr "Conversão"
 msgid "Conversion Rate"
 msgstr ""
 
+#: src/user/views/user/ConversionAlert.tsx:12
+msgid "Conversion reporting change"
+msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+msgstr ""
+
 #: src/components/Conversion/ConversionDisplay.tsx:46
-msgid "Conversion Type"
-msgstr "Tipo de Conversão"
+#~ msgid "Conversion Type"
+#~ msgstr "Tipo de Conversão"
 
 #: src/validation/CampaignSchema.tsx:151
 msgid "Conversion type must be Post Click or Post View"
@@ -684,7 +696,7 @@ msgstr "A URL de conversão não deve conter espaços em branco"
 msgid "Conversion URL must start with https://"
 msgstr "A URL de conversão deve começar com https://"
 
-#: src/components/Conversion/ConversionDisplay.tsx:56
+#: src/components/Conversion/ConversionDisplay.tsx:46
 msgid "Conversion URL Pattern"
 msgstr "Padrão de URL de Conversão"
 
@@ -712,7 +724,7 @@ msgstr ""
 msgid "Could not logout at this time. Please try again later."
 msgstr "Não foi possível fazer logout no momento. Por favor, tente novamente mais tarde."
 
-#: src/components/Conversion/ConversionFields.tsx:54
+#: src/components/Conversion/ConversionFields.tsx:34
 msgid "Count conversions within X days of an impression"
 msgstr "Contar conversões dentro de X dias de uma visualização"
 
@@ -971,7 +983,7 @@ msgstr "A data final deve ser após a data de início"
 msgid "End Time"
 msgstr "Horário de término"
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:26
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
 msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
 msgstr "Digite uma URL que represente o seu objetivo de conversão, como uma página de finalização de compra/checkout ou confirmação de inscrição. <0/>O Brave irá contabilizar as visitas únicas a essa página feitas por usuários que visualizaram ou clicaram no seu anúncio."
 
@@ -1382,7 +1394,7 @@ msgstr "Faça login em sua conta do Brave Ads"
 msgid "Logging in"
 msgstr "Fazendo login"
 
-#: src/components/Navigation/AccountMenu.tsx:136
+#: src/components/Navigation/AccountMenu.tsx:134
 msgid "Logout"
 msgstr ""
 
@@ -1538,8 +1550,7 @@ msgstr "Anúncio de notificação"
 msgid "Notification ads"
 msgstr "Anúncios de notificação"
 
-#: src/components/Conversion/ConversionDisplay.tsx:51
-#: src/components/Conversion/ConversionFields.tsx:48
+#: src/components/Conversion/ConversionFields.tsx:28
 msgid "Observation Window"
 msgstr "Janela de Observação"
 
@@ -1607,7 +1618,7 @@ msgstr "SO (Sistema Operacional)"
 msgid "Other (please specify)"
 msgstr "Outro (por favor, especifique)"
 
-#: src/components/Navigation/AccountMenu.tsx:106
+#: src/components/Navigation/AccountMenu.tsx:104
 msgid "Other accounts"
 msgstr ""
 
@@ -1711,20 +1722,20 @@ msgid "Please specify how you heard about Brave Ads"
 msgstr "Por favor, nos diga como você ficou sabendo sobre o Brave Ads"
 
 #: src/components/Conversion/ConversionFields.tsx:20
-msgid "Post-Click"
-msgstr "Pós-Clique"
+#~ msgid "Post-Click"
+#~ msgstr "Pós-Clique"
 
 #: src/components/Conversion/ConversionFields.tsx:28
-msgid "Post-Click: Viewed ad and converted by clicking its link"
-msgstr "Pós-Clique: Visualizou o anúncio e converteu ao clicar no link"
+#~ msgid "Post-Click: Viewed ad and converted by clicking its link"
+#~ msgstr "Pós-Clique: Visualizou o anúncio e converteu ao clicar no link"
 
 #: src/components/Conversion/ConversionFields.tsx:19
-msgid "Post-View"
-msgstr "Pós-Visualização"
+#~ msgid "Post-View"
+#~ msgstr "Pós-Visualização"
 
 #: src/components/Conversion/ConversionFields.tsx:24
-msgid "Post-View: Viewed ad and converted by visiting site on their own."
-msgstr "Pós-Visualização: Visualizou o anúncio e converteu ao visitar o site por conta própria."
+#~ msgid "Post-View: Viewed ad and converted by visiting site on their own."
+#~ msgstr "Pós-Visualização: Visualizou o anúncio e converteu ao visitar o site por conta própria."
 
 #: src/auth/views/MobileAdsBenefits.tsx:22
 #~ msgid "Powerful ad formats"
@@ -1828,9 +1839,13 @@ msgstr ""
 msgid "Remove"
 msgstr "Remover"
 
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:68
+msgid "Remove Conversion tracking"
+msgstr ""
+
 #: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:54
-msgid "Remove Conversion Tracking"
-msgstr "Remover Rastreamento de Conversão"
+#~ msgid "Remove Conversion Tracking"
+#~ msgstr "Remover Rastreamento de Conversão"
 
 #: src/user/analytics/analyticsOverview/reports/campaign/EngagementsOverview.tsx:117
 #~ msgid "Reporting not available yet for <0>{campaignName}</0>."
@@ -2245,8 +2260,8 @@ msgid "Try a free one-month test to see how Brave Search Ads perform for your br
 msgstr ""
 
 #: src/components/Conversion/ConversionFields.tsx:17
-msgid "Type"
-msgstr "Tipo"
+#~ msgid "Type"
+#~ msgstr "Tipo"
 
 #: src/components/Campaigns/CloneCampaign.tsx:43
 msgid "Unable to clone campaign"
@@ -2300,7 +2315,7 @@ msgstr "No momento, não foi possível cadastrar sua organização. Por favor, t
 #~ msgid "Unable to retrieve ad sets or ads for Campaign."
 #~ msgstr "Não foi possível recuperar conjuntos de anúncios ou anúncios para a Campanha."
 
-#: src/user/views/user/CampaignView.tsx:34
+#: src/user/views/user/CampaignView.tsx:35
 msgid "Unable to retrieve Campaign data."
 msgstr "Não foi possível recuperar os dados da Campanha."
 
@@ -2391,11 +2406,11 @@ msgstr "A URL não deve conter espaços em branco"
 msgid "URL must start with https://"
 msgstr "A URL deve começar com https://"
 
-#: src/components/Conversion/ConversionFields.tsx:38
+#: src/components/Conversion/ConversionFields.tsx:18
 msgid "URL Pattern"
 msgstr "Padrão de URL"
 
-#: src/components/Conversion/ConversionFields.tsx:40
+#: src/components/Conversion/ConversionFields.tsx:20
 msgid "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 msgstr "A URL deve ter um asterisco no final - Exemplo: https://brave.com/produtos/*"
 

--- a/src/locales/test.po
+++ b/src/locales/test.po
@@ -49,11 +49,11 @@ msgstr ""
 msgid "+{count} more"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:50
+#: src/components/Conversion/ConversionFields.tsx:30
 msgid "1 Day"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:52
+#: src/components/Conversion/ConversionFields.tsx:32
 msgid "30 Days"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "401 Forbidden"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:51
+#: src/components/Conversion/ConversionFields.tsx:31
 msgid "7 Days"
 msgstr ""
 
@@ -79,7 +79,7 @@ msgstr ""
 
 #: src/components/Drawer/MiniSideBar.tsx:57
 #: src/components/Navigation/AccountMenu.tsx:36
-#: src/components/Navigation/AccountMenu.tsx:97
+#: src/components/Navigation/AccountMenu.tsx:95
 #: src/user/settings/Settings.tsx:49
 msgid "Account"
 msgstr ""
@@ -190,7 +190,7 @@ msgstr ""
 msgid "Add an existing ad"
 msgstr ""
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:44
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:45
 msgid "Add Conversion tracking"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 
 #: src/components/Creatives/CreativeCampaigns.tsx:40
 #: src/components/Drawer/MiniSideBar.tsx:22
-#: src/user/views/user/CampaignView.tsx:42
+#: src/user/views/user/CampaignView.tsx:45
 msgid "Campaigns"
 msgstr ""
 
@@ -647,8 +647,12 @@ msgid "Continue"
 msgstr ""
 
 #: src/components/Conversion/ConversionDisplay.tsx:18
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:20
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:21
 msgid "Conversion"
+msgstr ""
+
+#: src/components/Conversion/ConversionDisplay.tsx:51
+msgid "Conversion Observation Window"
 msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:70
@@ -660,9 +664,17 @@ msgstr ""
 msgid "Conversion Rate"
 msgstr ""
 
-#: src/components/Conversion/ConversionDisplay.tsx:46
-msgid "Conversion Type"
+#: src/user/views/user/ConversionAlert.tsx:12
+msgid "Conversion reporting change"
 msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+msgstr ""
+
+#: src/components/Conversion/ConversionDisplay.tsx:46
+#~ msgid "Conversion Type"
+#~ msgstr ""
 
 #: src/validation/CampaignSchema.tsx:151
 msgid "Conversion type must be Post Click or Post View"
@@ -684,7 +696,7 @@ msgstr ""
 msgid "Conversion URL must start with https://"
 msgstr ""
 
-#: src/components/Conversion/ConversionDisplay.tsx:56
+#: src/components/Conversion/ConversionDisplay.tsx:46
 msgid "Conversion URL Pattern"
 msgstr ""
 
@@ -712,7 +724,7 @@ msgstr ""
 msgid "Could not logout at this time. Please try again later."
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:54
+#: src/components/Conversion/ConversionFields.tsx:34
 msgid "Count conversions within X days of an impression"
 msgstr ""
 
@@ -972,7 +984,7 @@ msgstr ""
 msgid "End Time"
 msgstr ""
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:26
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
 msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
 msgstr ""
 
@@ -1383,7 +1395,7 @@ msgstr ""
 msgid "Logging in"
 msgstr ""
 
-#: src/components/Navigation/AccountMenu.tsx:136
+#: src/components/Navigation/AccountMenu.tsx:134
 msgid "Logout"
 msgstr ""
 
@@ -1539,8 +1551,7 @@ msgstr ""
 msgid "Notification ads"
 msgstr ""
 
-#: src/components/Conversion/ConversionDisplay.tsx:51
-#: src/components/Conversion/ConversionFields.tsx:48
+#: src/components/Conversion/ConversionFields.tsx:28
 msgid "Observation Window"
 msgstr ""
 
@@ -1608,7 +1619,7 @@ msgstr ""
 msgid "Other (please specify)"
 msgstr ""
 
-#: src/components/Navigation/AccountMenu.tsx:106
+#: src/components/Navigation/AccountMenu.tsx:104
 msgid "Other accounts"
 msgstr ""
 
@@ -1712,20 +1723,20 @@ msgid "Please specify how you heard about Brave Ads"
 msgstr ""
 
 #: src/components/Conversion/ConversionFields.tsx:20
-msgid "Post-Click"
-msgstr ""
+#~ msgid "Post-Click"
+#~ msgstr ""
 
 #: src/components/Conversion/ConversionFields.tsx:28
-msgid "Post-Click: Viewed ad and converted by clicking its link"
-msgstr ""
+#~ msgid "Post-Click: Viewed ad and converted by clicking its link"
+#~ msgstr ""
 
 #: src/components/Conversion/ConversionFields.tsx:19
-msgid "Post-View"
-msgstr ""
+#~ msgid "Post-View"
+#~ msgstr ""
 
 #: src/components/Conversion/ConversionFields.tsx:24
-msgid "Post-View: Viewed ad and converted by visiting site on their own."
-msgstr ""
+#~ msgid "Post-View: Viewed ad and converted by visiting site on their own."
+#~ msgstr ""
 
 #: src/auth/views/MobileAdsBenefits.tsx:22
 #~ msgid "Powerful ad formats"
@@ -1829,9 +1840,13 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:54
-msgid "Remove Conversion Tracking"
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:68
+msgid "Remove Conversion tracking"
 msgstr ""
+
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:54
+#~ msgid "Remove Conversion Tracking"
+#~ msgstr ""
 
 #: src/user/analytics/analyticsOverview/reports/campaign/EngagementsOverview.tsx:117
 #~ msgid "Reporting not available yet for <0>{campaignName}</0>."
@@ -2246,8 +2261,8 @@ msgid "Try a free one-month test to see how Brave Search Ads perform for your br
 msgstr ""
 
 #: src/components/Conversion/ConversionFields.tsx:17
-msgid "Type"
-msgstr ""
+#~ msgid "Type"
+#~ msgstr ""
 
 #: src/components/Campaigns/CloneCampaign.tsx:43
 msgid "Unable to clone campaign"
@@ -2301,7 +2316,7 @@ msgstr ""
 #~ msgid "Unable to retrieve ad sets or ads for Campaign."
 #~ msgstr ""
 
-#: src/user/views/user/CampaignView.tsx:34
+#: src/user/views/user/CampaignView.tsx:35
 msgid "Unable to retrieve Campaign data."
 msgstr ""
 
@@ -2392,11 +2407,11 @@ msgstr ""
 msgid "URL must start with https://"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:38
+#: src/components/Conversion/ConversionFields.tsx:18
 msgid "URL Pattern"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:40
+#: src/components/Conversion/ConversionFields.tsx:20
 msgid "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 msgstr ""
 

--- a/src/locales/test.po
+++ b/src/locales/test.po
@@ -49,11 +49,11 @@ msgstr ""
 msgid "+{count} more"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:30
+#: src/components/Conversion/ConversionFields.tsx:31
 msgid "1 Day"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:32
+#: src/components/Conversion/ConversionFields.tsx:33
 msgid "30 Days"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "401 Forbidden"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:31
+#: src/components/Conversion/ConversionFields.tsx:32
 msgid "7 Days"
 msgstr ""
 
@@ -214,6 +214,10 @@ msgstr ""
 
 #: src/user/ads/AdsExistingAd.tsx:80
 msgid "Ads are modular building blocks that can be paired with ad sets to build unique combinations. Your previously approved ads will show here. Select by using the box next to the name. Use the \"Complete selection\" button to finish."
+msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:36
+msgid "Ads Help Center"
 msgstr ""
 
 #: src/routes/campaigns/analytics/breakdowns.tsx:135
@@ -669,8 +673,16 @@ msgid "Conversion reporting change"
 msgstr ""
 
 #: src/user/views/user/ConversionAlert.tsx:14
-msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+#~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at in the <0/>"
+#~ msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 msgstr ""
+
+#: src/user/views/user/ConversionAlert.tsx:14
+#~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at: <0/>"
+#~ msgstr ""
 
 #: src/components/Conversion/ConversionDisplay.tsx:46
 #~ msgid "Conversion Type"
@@ -725,8 +737,8 @@ msgid "Could not logout at this time. Please try again later."
 msgstr ""
 
 #: src/components/Conversion/ConversionFields.tsx:34
-msgid "Count conversions within X days of an impression"
-msgstr ""
+#~ msgid "Count conversions within X days of an impression"
+#~ msgstr ""
 
 #: src/user/analytics/analyticsOverview/components/MetricSelect.tsx:46
 #~ msgid "Counted if the user clicks an ad and spends at least 10 seconds on the advertiser's website, with the website open in an active browser tab. The 10 seconds must be spent on the site after arriving by clicking the ad link, and the tab must remain open and active the entire time for the visit to count."
@@ -852,6 +864,10 @@ msgstr ""
 
 #: src/user/views/adsManager/views/advanced/components/campaign/CampaignSettings.tsx:27
 msgid "Define how you want your campaign to run."
+msgstr ""
+
+#: src/components/Conversion/ConversionFields.tsx:37
+msgid "Define the number of days Brave will observe conversions and attribute them to the campaign."
 msgstr ""
 
 #: src/user/ads/AdList.tsx:66
@@ -985,8 +1001,12 @@ msgid "End Time"
 msgstr ""
 
 #: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
-msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
+msgid "Enter a URL that indicates a desired action you want to measure, like a subscription or purchase confirmation page. Brave will count unique visits to that page as conversions if a user has seen or clicked your ad."
 msgstr ""
+
+#: src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx:27
+#~ msgid "Enter a URL that represents your conversion goal, like a checkout or subscription confirmation page. <0/>Brave will count unique visits to that page from users who saw or clicked your ad."
+#~ msgstr ""
 
 #: src/auth/components/AdvertiserDetailsForm.tsx:118
 msgid "Enter Ads Manager"
@@ -1551,7 +1571,7 @@ msgstr ""
 msgid "Notification ads"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:28
+#: src/components/Conversion/ConversionFields.tsx:29
 msgid "Observation Window"
 msgstr ""
 
@@ -2407,11 +2427,11 @@ msgstr ""
 msgid "URL must start with https://"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:18
+#: src/components/Conversion/ConversionFields.tsx:19
 msgid "URL Pattern"
 msgstr ""
 
-#: src/components/Conversion/ConversionFields.tsx:20
+#: src/components/Conversion/ConversionFields.tsx:21
 msgid "URL should have a trailing asterisk - Example: https://brave.com/products/*"
 msgstr ""
 

--- a/src/user/views/adsManager/types/index.ts
+++ b/src/user/views/adsManager/types/index.ts
@@ -74,9 +74,9 @@ export type Creative = CreativeInput & {
 };
 
 export const initialConversion: Conversion = {
-  type: "",
+  type: "postclick",
   urlPattern: "",
-  observationWindow: 0,
+  observationWindow: 30,
 };
 
 export const initialCreative: Creative = {

--- a/src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx
@@ -1,9 +1,10 @@
-import { Button, Link, Stack, Typography } from "@mui/material";
+import { Button, Stack, Typography } from "@mui/material";
 import { ConversionFields } from "@/components/Conversion/ConversionFields";
 import { FieldArray, FieldArrayRenderProps, useField } from "formik";
 import { Conversion, initialConversion } from "../../../../../types";
 import { CardContainer } from "@/components/Card/CardContainer";
-import { Add } from "@mui/icons-material";
+import AddIcon from "@mui/icons-material/Add";
+import RemoveIcon from "@mui/icons-material/Remove";
 import { LearnMoreButton } from "@/components/Button/LearnMoreButton";
 import { Trans } from "@lingui/macro";
 
@@ -37,22 +38,12 @@ export function ConversionField({ index }: Props) {
                   onClick={() => helper.push(initialConversion)}
                   sx={{
                     maxWidth: 300,
-                    borderRadius: "16px",
+                    borderRadius: "10px",
                   }}
-                  endIcon={<Add />}
+                  endIcon={<AddIcon />}
                 >
                   <Trans>Add Conversion tracking</Trans>
                 </Button>
-              )}
-              {hasConversions && (
-                <Link
-                  underline="none"
-                  variant="body2"
-                  onClick={() => helper.remove(0)}
-                  sx={{ cursor: "pointer" }}
-                >
-                  <Trans>Remove Conversion Tracking</Trans>
-                </Link>
               )}
             </Stack>
 
@@ -62,6 +53,21 @@ export function ConversionField({ index }: Props) {
                 name={`adSets.${index}.conversions.${idx}`}
               />
             ))}
+
+            {hasConversions && (
+              <Button
+                variant="contained"
+                onClick={() => helper.remove(0)}
+                sx={{
+                  maxWidth: 300,
+                  borderRadius: "10px",
+                  mt: 1,
+                }}
+                endIcon={<RemoveIcon />}
+              >
+                <Trans>Remove Conversion tracking</Trans>
+              </Button>
+            )}
           </>
         )}
       </FieldArray>

--- a/src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/adSet/fields/ConversionField.tsx
@@ -25,10 +25,10 @@ export function ConversionField({ index }: Props) {
             <Stack direction={hasConversions ? "row" : "column"} spacing={1}>
               <Typography variant="body2" sx={{ mb: 2 }}>
                 <Trans>
-                  Enter a URL that represents your conversion goal, like a
-                  checkout or subscription confirmation page. <br />
-                  Brave will count unique visits to that page from users who saw
-                  or clicked your ad.
+                  Enter a URL that indicates a desired action you want to
+                  measure, like a subscription or purchase confirmation page.
+                  Brave will count unique visits to that page as conversions if
+                  a user has seen or clicked your ad.
                 </Trans>{" "}
                 <LearnMoreButton helpSection="campaign-performance/reporting#conversion-reporting-in-brave-ads-manager" />
               </Typography>

--- a/src/user/views/user/CampaignView.tsx
+++ b/src/user/views/user/CampaignView.tsx
@@ -11,6 +11,7 @@ import { useTrackMatomoPageView } from "@/hooks/useTrackWithMatomo";
 import { Trans, msg } from "@lingui/macro";
 import { AdvertiserCampaignsDocument } from "@/graphql-client/graphql";
 import { useQuery } from "@apollo/client";
+import { ConversionAlert } from "@/user/views/user/ConversionAlert";
 
 export function CampaignView() {
   useTrackMatomoPageView({ documentTitle: "Advertiser Campaigns" });
@@ -38,22 +39,25 @@ export function CampaignView() {
 
   return (
     <MiniSideBar>
-      <CardContainer
-        header={<Trans>Campaigns</Trans>}
-        sx={{
-          flexGrow: 1,
-          overflowX: "auto",
-        }}
-        additionalAction={<CampaignAgeFilter disabled={loading} />}
-      >
-        {!loading ? (
-          <CampaignList advertiser={data?.advertiserCampaigns} />
-        ) : (
-          <Box m={3}>
-            <Skeleton variant="rounded" height={500} />
-          </Box>
-        )}
-      </CardContainer>
+      <Box display="flex" overflow="auto" flexDirection="column">
+        <ConversionAlert />
+        <CardContainer
+          header={<Trans>Campaigns</Trans>}
+          sx={{
+            flexGrow: 1,
+            overflowX: "auto",
+          }}
+          additionalAction={<CampaignAgeFilter disabled={loading} />}
+        >
+          {!loading ? (
+            <CampaignList advertiser={data?.advertiserCampaigns} />
+          ) : (
+            <Box m={3}>
+              <Skeleton variant="rounded" height={500} />
+            </Box>
+          )}
+        </CardContainer>
+      </Box>
     </MiniSideBar>
   );
 }

--- a/src/user/views/user/ConversionAlert.tsx
+++ b/src/user/views/user/ConversionAlert.tsx
@@ -1,0 +1,36 @@
+import { Alert, AlertTitle, Collapse, Link } from "@mui/material";
+import { Trans } from "@lingui/macro";
+import { useStickyState } from "@/hooks/useStickyState";
+
+export function ConversionAlert() {
+  const [ack, setAck] = useStickyState("conversion-alert-message", true);
+
+  return (
+    <Collapse in={ack}>
+      <Alert severity="warning" onClose={() => setAck(false)} sx={{ mt: 2 }}>
+        <AlertTitle>
+          <Trans>Conversion reporting change</Trans>
+        </AlertTitle>
+        <Trans>
+          Conversion reporting for Brave Ads has changed to better uphold user
+          privacy and security. Campaigns with conversion URLs that violate the
+          newly clarified requirements for conversion URLs will now
+          automatically be paused until their URLs have been updated. Please
+          review the guidelines and take any necessary action to prevent
+          campaign disruption. New guidelines can be found at: <GuidelineLink />
+        </Trans>
+      </Alert>
+    </Collapse>
+  );
+}
+
+function GuidelineLink() {
+  const link =
+    "https://ads-help.brave.com/campaign-performance/reporting/#conversion-reporting-in-brave-ads-manager";
+
+  return (
+    <Link href={link} target="_blank" rel="noreferrer" variant="inherit">
+      {link}
+    </Link>
+  );
+}

--- a/src/user/views/user/ConversionAlert.tsx
+++ b/src/user/views/user/ConversionAlert.tsx
@@ -17,7 +17,8 @@ export function ConversionAlert() {
           newly clarified requirements for conversion URLs will now
           automatically be paused until their URLs have been updated. Please
           review the guidelines and take any necessary action to prevent
-          campaign disruption. New guidelines can be found at: <GuidelineLink />
+          campaign disruption. New guidelines can be found at the{" "}
+          <GuidelineLink />
         </Trans>
       </Alert>
     </Collapse>
@@ -25,12 +26,14 @@ export function ConversionAlert() {
 }
 
 function GuidelineLink() {
-  const link =
-    "https://ads-help.brave.com/campaign-performance/reporting/#conversion-reporting-in-brave-ads-manager";
-
   return (
-    <Link href={link} target="_blank" rel="noreferrer" variant="inherit">
-      {link}
+    <Link
+      href="https://ads-help.brave.com/campaign-performance/reporting/#conversion-reporting-in-brave-ads-manager"
+      target="_blank"
+      rel="noreferrer"
+      variant="inherit"
+    >
+      <Trans>Ads Help Center</Trans>
     </Link>
   );
 }


### PR DESCRIPTION
Lets the end user know conversions have stricter enforcement:


<img width="1624" alt="Screen Shot 2024-07-03 at 1 44 18 PM" src="https://github.com/brave/ads-ui/assets/48930920/242a948a-9c2a-4b3d-af0f-60a04909a1d3">

---

<img width="1179" alt="Screen Shot 2024-07-03 at 2 02 00 PM" src="https://github.com/brave/ads-ui/assets/48930920/6dddd5d3-513c-4f0d-b25d-6a23200c7078">

