### PR TITLE
feat: default localization from browser navigator

### DIFF
--- a/src/basic-attention-token/BasicAttentionTokenLandingPage.tsx
+++ b/src/basic-attention-token/BasicAttentionTokenLandingPage.tsx
@@ -79,7 +79,7 @@ function LaunchCampaignButton() {
           trackMatomoEvent("basic-attention-token", "launch-campaign")
         }
         sx={{
-          width: "250px",
+          width: "300px",
           maxHeight: { xs: "40px", md: "60px" },
           mb: 1,
           fontSize: "16px",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,4 @@
-import { detect, fromUrl } from "@lingui/detect-locale";
+import { detect, fromNavigator } from "@lingui/detect-locale";
 import { enUS, esES, ptBR } from "@mui/x-data-grid/locales";
 
 import benefits from "@/assets/images/ad-benefits.svg";
@@ -27,7 +27,7 @@ export function findLocale() {
   let gridTheme = enUS;
   let images = { benefits };
 
-  const detectedLocale = detect(fromUrl("lang") /*fromNavigator(), */);
+  const detectedLocale = detect(fromNavigator());
 
   if (detectedLocale) {
     const matchedLocale = locales.find((l) =>

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -29,7 +29,7 @@ msgstr "{campaignFormat} pricing configuration option(s):"
 msgid "{length}/{maxLength} characters"
 msgstr "{length}/{maxLength} characters"
 
-#: src/components/Switch/OnOff.tsx:44
+#: src/components/Switch/OnOff.tsx:46
 msgid "{type} status cannot be updated"
 msgstr "{type} status cannot be updated"
 
@@ -82,8 +82,8 @@ msgstr "About Brave Ads"
 #~ msgstr "Access dashboard"
 
 #: src/components/Drawer/MiniSideBar.tsx:57
-#: src/components/Navigation/AccountMenu.tsx:36
-#: src/components/Navigation/AccountMenu.tsx:95
+#: src/components/Navigation/AccountMenu.tsx:43
+#: src/components/Navigation/AccountMenu.tsx:102
 #: src/user/settings/Settings.tsx:49
 msgid "Account"
 msgstr "Account"
@@ -1213,7 +1213,7 @@ msgstr "Get to your first million users with powerful ad placements on the world
 msgid "Help Center"
 msgstr "Help Center"
 
-#: src/components/Navigation/AccountMenu.tsx:82
+#: src/components/Navigation/AccountMenu.tsx:89
 msgid "Hi"
 msgstr "Hi"
 
@@ -1319,7 +1319,7 @@ msgstr "In a video on YouTube"
 #~ msgid "In the meantime, check out our <0>advertiser resources</0>. If you have any questions, please reach out to <1>selfserve@brave.com</1>."
 #~ msgstr "In the meantime, check out our <0>advertiser resources</0>. If you have any questions, please reach out to <1>selfserve@brave.com</1>."
 
-#: src/components/Datagrid/renderers.tsx:34
+#: src/components/Datagrid/renderers.tsx:35
 msgid "In your local time this is"
 msgstr "In your local time this is"
 
@@ -1471,7 +1471,7 @@ msgstr "Log into your Brave Ads account"
 msgid "Logging in"
 msgstr "Logging in"
 
-#: src/components/Navigation/AccountMenu.tsx:134
+#: src/components/Navigation/AccountMenu.tsx:141
 msgid "Logout"
 msgstr "Logout"
 
@@ -1592,7 +1592,7 @@ msgstr "Newsfeed ads"
 msgid "Next"
 msgstr "Next"
 
-#: src/components/Datagrid/renderers.tsx:70
+#: src/components/Datagrid/renderers.tsx:71
 msgid "No"
 msgstr "No"
 
@@ -1711,7 +1711,7 @@ msgstr "OS"
 msgid "Other (please specify)"
 msgstr "Other (please specify)"
 
-#: src/components/Navigation/AccountMenu.tsx:104
+#: src/components/Navigation/AccountMenu.tsx:111
 msgid "Other accounts"
 msgstr "Other accounts"
 
@@ -2143,7 +2143,7 @@ msgstr "Something went wrong."
 msgid "Spend"
 msgstr "Spend"
 
-#: src/components/Creatives/SearchPreview.tsx:247
+#: src/components/Creatives/SearchPreview.tsx:249
 msgid "Sponsored"
 msgstr "Sponsored"
 
@@ -2268,7 +2268,7 @@ msgstr "Target URL is a required field"
 msgid "Target URL is not valid"
 msgstr "Target URL is not valid"
 
-#: src/components/Creatives/hooks/useGetCreativeDetails.tsx:23
+#: src/components/Creatives/hooks/useGetCreativeDetails.tsx:24
 msgid "Target URL not validated"
 msgstr "Target URL not validated"
 
@@ -2587,7 +2587,7 @@ msgstr "Value"
 msgid "Verified Conversions Report"
 msgstr "Verified Conversions Report"
 
-#: src/components/Navigation/AccountMenu.tsx:92
+#: src/components/Navigation/AccountMenu.tsx:99
 msgid "View profile"
 msgstr "View profile"
 
@@ -2665,7 +2665,7 @@ msgstr "Windows"
 msgid "Work email"
 msgstr "Work email"
 
-#: src/components/Datagrid/renderers.tsx:70
+#: src/components/Datagrid/renderers.tsx:71
 msgid "Yes"
 msgstr "Yes"
 

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -2250,7 +2250,7 @@ msgstr "¡Responda nuestra encuesta!"
 
 #: src/search/SearchLandingPage.tsx:36
 msgid "Tap into more than <0>9 billion</0> annual Web searches"
-msgstr "Aproveche más de <0>9 mil millones<0> de búsquedas web anuales"
+msgstr "Aproveche más de <0>9 mil millones</0> de búsquedas web anuales"
 
 #: src/search/SearchLandingPage.tsx:32
 #~ msgid "Tap into over <0>9 billion</0> annual Web searches"
@@ -2741,4 +2741,3 @@ msgstr "Su campaña de prueba será revisada por un Gerente de Cuenta. Agregue c
 #: src/auth/components/AdvertiserAddress.tsx:51
 msgid "Zip / Postal Code"
 msgstr "Código postal"
-


### PR DESCRIPTION
We now have everything translated, lets default it:
```
Catalog statistics for src/locales/{locale}: 
┌─────────────┬─────────────┬─────────┐
│ Language    │ Total count │ Missing │
├─────────────┼─────────────┼─────────┤
│ en (source) │     652     │    -    │
│ es          │     652     │    0    │
│ pt          │     652     │    0    │
│ test        │     615     │   615   │
└─────────────┴─────────────┴─────────┘
```