### PR TITLE
fix: don't refresh search preview data

### DIFF
--- a/src/search/preview/data.ts
+++ b/src/search/preview/data.ts
@@ -1,7 +1,7 @@
 /* eslint-disable lingui/no-unlocalized-strings */
 import { CountryDomain } from "@/user/views/user/search/types";
 import { buildAdServerEndpoint } from "@/util/environment";
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 
 /* this is the data we get back from the server */
 interface ServerSearchData {
@@ -57,7 +57,7 @@ const fetcher = (suffix: string) =>
 export function useLandingPageData(
   slug: string,
 ): UseSearchDataReturn<SearchData> {
-  const { data, isLoading } = useSWR<ServerSearchData>(slug, fetcher);
+  const { data, isLoading } = useSWRImmutable<ServerSearchData>(slug, fetcher);
 
   if (!data) {
     return { loading: isLoading };
@@ -80,7 +80,7 @@ export function useKeywordData(
   landingPageUrl: string,
 ): UseSearchDataReturn<string[]> {
   const qs = new URLSearchParams({ url: landingPageUrl });
-  const { data, isLoading } = useSWR<string[]>(
+  const { data, isLoading } = useSWRImmutable<string[]>(
     `${slug}/keywords?${qs}`,
     fetcher,
   );


### PR DESCRIPTION
The default of swr is to refresh the data on screen activation, network reconnect etc. This is not needed for the search preview data as the data is very unlikely to change within one user session, generating needless requests that return the same data.

See https://swr.vercel.app/docs/revalidation#disable-automatic-revalidations