### PR TITLE
feat(search-preview): include total landing page count

### DIFF
--- a/src/search/preview/SummaryPanel.tsx
+++ b/src/search/preview/SummaryPanel.tsx
@@ -8,6 +8,7 @@ import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 import PanToolAltOutlinedIcon from "@mui/icons-material/PanToolAltOutlined";
 import MonetizationOnOutlinedIcon from "@mui/icons-material/MonetizationOnOutlined";
 import PercentIcon from "@mui/icons-material/Percent";
+import ArticleIcon from "@mui/icons-material/Article";
 import { SearchData } from "./data";
 import { formatUsd, formatWholeNumber } from "@/user/library/format";
 
@@ -61,6 +62,12 @@ export function SummaryPanel({ searchData }: Props) {
         value={searchData.countryDomain.domain}
         icon={<DomainIcon sx={{ color: "text.secondary" }} />}
       />
+      <SummaryEntry
+        title="Landing Pages"
+        value={formatWholeNumber(searchData.estimates.landingPages)}
+        icon={<ArticleIcon sx={{ color: "text.secondary" }} />}
+      />
+
       <Typography variant="h2" marginTop={3} marginBottom={1}>
         Estimated weekly results
       </Typography>

--- a/src/search/preview/data.ts
+++ b/src/search/preview/data.ts
@@ -18,6 +18,7 @@ interface ServerSearchData {
       max: number;
     };
     trialBudget: number;
+    landingPages: number;
   };
 }
 


### PR DESCRIPTION

<img width="276" alt="Screenshot 2024-07-26 at 10 48 55" src="https://github.com/user-attachments/assets/3bc5891a-92c6-484c-9681-37c1250accb1">

Closes https://github.com/brave/ads-serve/issues/4151

## Depends on
- [x] https://github.com/brave/ads-serve/pull/4153
