### PR TITLE
fix(graphql): cannot pass image dimenions when updating a creative

### DIFF
--- a/src/components/Creatives/hooks/useSubmitCreative.tsx
+++ b/src/components/Creatives/hooks/useSubmitCreative.tsx
@@ -79,7 +79,10 @@ export function useSubmitCreative(props: { id: string }) {
               input: {
                 id: props.id,
                 payloadNotification: input.payloadNotification,
-                payloadInlineContent: input.payloadInlineContent,
+                payloadInlineContent: _.omit(
+                  input.payloadInlineContent,
+                  "dimensions",
+                ),
               },
             },
           });


### PR DESCRIPTION
As we transition to new mutations, some discrepancies can pop up. This is one of them.