### PR TITLE
fix: remove outer container that had conversion alert in it

### DIFF
--- a/src/user/views/user/CampaignView.tsx
+++ b/src/user/views/user/CampaignView.tsx
@@ -38,24 +38,22 @@ export function CampaignView() {
 
   return (
     <MiniSideBar>
-      <Box display="flex" overflow="auto" flexDirection="column">
-        <CardContainer
-          header={<Trans>Campaigns</Trans>}
-          sx={{
-            flexGrow: 1,
-            overflowX: "auto",
-          }}
-          additionalAction={<CampaignAgeFilter disabled={loading} />}
-        >
-          {!loading ? (
-            <CampaignList advertiser={data?.advertiserCampaigns} />
-          ) : (
-            <Box m={3}>
-              <Skeleton variant="rounded" height={500} />
-            </Box>
-          )}
-        </CardContainer>
-      </Box>
+      <CardContainer
+        header={<Trans>Campaigns</Trans>}
+        sx={{
+          flexGrow: 1,
+          overflowX: "auto",
+        }}
+        additionalAction={<CampaignAgeFilter disabled={loading} />}
+      >
+        {!loading ? (
+          <CampaignList advertiser={data?.advertiserCampaigns} />
+        ) : (
+          <Box m={3}>
+            <Skeleton variant="rounded" height={500} />
+          </Box>
+        )}
+      </CardContainer>
     </MiniSideBar>
   );
 }


### PR DESCRIPTION
Alert was removed, but the container was not.
Fix related to: https://github.com/brave/ads-ui/pull/1292