### PR TITLE
fix: missed translations in auth flow

### DIFF
--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -331,6 +331,9 @@ msgstr "Check if your brand is eligible for a <0>free trial</0> of Brave Search 
 msgid "Check your brand's eligibility"
 msgstr "Check your brand's eligibility"
 
+msgid "Check your spam folder or <0>return to the login page</0> to try again."
+msgstr "Check your spam folder or <0>return to the login page</0> to try again."
+
 msgid "Choose"
 msgstr "Choose"
 
@@ -351,6 +354,9 @@ msgstr "Click Here!"
 
 msgid "Click on the secure login link in the email to access your Brave Ads account."
 msgstr "Click on the secure login link in the email to access your Brave Ads account."
+
+msgid "Click the continue button below to complete the login process."
+msgstr "Click the continue button below to complete the login process."
 
 msgid "Click Through Rate"
 msgstr "Click Through Rate"
@@ -553,8 +559,11 @@ msgstr "Domain must not contain any whitespace"
 msgid "Domain to advertise"
 msgstr "Domain to advertise"
 
-msgid "Don’t see the email? Check your spam folder or <0>try again.</0>"
-msgstr "Don’t see the email? Check your spam folder or <0>try again.</0>"
+msgid "Don’t see the email?"
+msgstr "Don’t see the email?"
+
+#~ msgid "Don’t see the email? Check your spam folder or <0>try again.</0>"
+#~ msgstr "Don’t see the email? Check your spam folder or <0>try again.</0>"
 
 msgid "Download Report"
 msgstr "Download Report"
@@ -850,8 +859,8 @@ msgstr "Log in"
 msgid "Log into your Brave Ads account"
 msgstr "Log into your Brave Ads account"
 
-msgid "Logging in"
-msgstr "Logging in"
+#~ msgid "Logging in"
+#~ msgstr "Logging in"
 
 msgid "Logout"
 msgstr "Logout"
@@ -946,8 +955,8 @@ msgstr "No previous ads available"
 msgid "no session created"
 msgstr "no session created"
 
-msgid "Not automatically redirected? Click this link to go to the dashboard."
-msgstr "Not automatically redirected? Click this link to go to the dashboard."
+#~ msgid "Not automatically redirected? Click this link to go to the dashboard."
+#~ msgstr "Not automatically redirected? Click this link to go to the dashboard."
 
 msgid "Notes"
 msgstr "Notes"
@@ -1129,8 +1138,11 @@ msgstr "Remove"
 msgid "Remove Conversion tracking"
 msgstr "Remove Conversion tracking"
 
-msgid "Request another link."
-msgstr "Request another link."
+#~ msgid "Request another link."
+#~ msgstr "Request another link."
+
+msgid "Return"
+msgstr "Return"
 
 msgid "Return to dashboard"
 msgstr "Return to dashboard"
@@ -1270,8 +1282,8 @@ msgstr "Submit"
 msgid "Success! Check your email."
 msgstr "Success! Check your email."
 
-msgid "Successfully logged in!"
-msgstr "Successfully logged in!"
+#~ msgid "Successfully logged in!"
+#~ msgstr "Successfully logged in!"
 
 msgid "Support"
 msgstr "Support"
@@ -1306,11 +1318,17 @@ msgstr "Terms & Conditions acknowledgement is required"
 msgid "The <0>Basic Attention Token (BAT)</0> is Brave’s native crypto token. Brave Browser users who opt into <1>Brave Rewards</1> can earn BAT just for opting into viewing ads from the Brave Ads network. Earners can hold BAT like any other crypto asset, trade it, cash it in, or even donate it to their favorite creators."
 msgstr "The <0>Basic Attention Token (BAT)</0> is Brave’s native crypto token. Brave Browser users who opt into <1>Brave Rewards</1> can earn BAT just for opting into viewing ads from the Brave Ads network. Earners can hold BAT like any other crypto asset, trade it, cash it in, or even donate it to their favorite creators."
 
+msgid "The campaign will likely stop running before the end date provided due to budget constraints."
+msgstr "The campaign will likely stop running before the end date provided due to budget constraints."
+
 msgid "The current value for this metric may be an underestimate."
 msgstr "The current value for this metric may be an underestimate."
 
 msgid "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
 msgstr "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
+
+msgid "The magic link you have requested has either expired or has already been used. Please return to the login page and try again."
+msgstr "The magic link you have requested has either expired or has already been used. Please return to the login page and try again."
 
 msgid "The username or password did not match our records."
 msgstr "The username or password did not match our records."
@@ -1378,8 +1396,11 @@ msgstr "Unable to load ad"
 msgid "Unable to load reporting details for campaign: {0}"
 msgstr "Unable to load reporting details for campaign: {0}"
 
-msgid "Unable to login, link has expired or has already been used."
-msgstr "Unable to login, link has expired or has already been used."
+#~ msgid "Unable to login, link has expired or has already been used."
+#~ msgstr "Unable to login, link has expired or has already been used."
+
+msgid "Unable to login."
+msgstr "Unable to login."
 
 msgid "Unable to register your organization at this time. Please try again later."
 msgstr "Unable to register your organization at this time. Please try again later."
@@ -1506,6 +1527,9 @@ msgstr "Yes"
 
 msgid "You are attempting to create a new keypair, this will replace any of your account’s existing keypairs. Please note, previous keypairs cannot be retrieved or used once replaced."
 msgstr "You are attempting to create a new keypair, this will replace any of your account’s existing keypairs. Please note, previous keypairs cannot be retrieved or used once replaced."
+
+msgid "You are logging into the Brave Ads Manager Dashboard."
+msgstr "You are logging into the Brave Ads Manager Dashboard."
 
 msgid "You have {0} errors that must be fixed before submitting."
 msgstr "You have {0} errors that must be fixed before submitting."

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -336,6 +336,9 @@ msgstr ""
 msgid "Check your brand's eligibility"
 msgstr ""
 
+msgid "Check your spam folder or <0>return to the login page</0> to try again."
+msgstr ""
+
 msgid "Choose"
 msgstr "Elegir"
 
@@ -356,6 +359,9 @@ msgstr "¡Haga clic aquí!"
 
 msgid "Click on the secure login link in the email to access your Brave Ads account."
 msgstr "Haga clic en el enlace de inicio de sesión seguro del correo electrónico para acceder a su cuenta de Brave Ads."
+
+msgid "Click the continue button below to complete the login process."
+msgstr ""
 
 msgid "Click Through Rate"
 msgstr "Clic por calificaciones"
@@ -558,8 +564,11 @@ msgstr "El dominio no debe contener espacios en blanco"
 msgid "Domain to advertise"
 msgstr "Dominio para publicitar"
 
-msgid "Don’t see the email? Check your spam folder or <0>try again.</0>"
-msgstr "¿No ve el correo electrónico? Revise su carpeta de correo no deseado o <0>inténtelo de nuevo.</0>"
+msgid "Don’t see the email?"
+msgstr ""
+
+#~ msgid "Don’t see the email? Check your spam folder or <0>try again.</0>"
+#~ msgstr "¿No ve el correo electrónico? Revise su carpeta de correo no deseado o <0>inténtelo de nuevo.</0>"
 
 msgid "Download Report"
 msgstr "Descargar informe"
@@ -855,8 +864,8 @@ msgstr "Iniciar sesión"
 msgid "Log into your Brave Ads account"
 msgstr "Inicie sesión en su cuenta de Brave Ads"
 
-msgid "Logging in"
-msgstr "Iniciando sesión"
+#~ msgid "Logging in"
+#~ msgstr "Iniciando sesión"
 
 msgid "Logout"
 msgstr "Cerrar sesión"
@@ -951,8 +960,8 @@ msgstr "No hay anuncios anteriores disponibles"
 msgid "no session created"
 msgstr "no se ha creado ninguna sesión"
 
-msgid "Not automatically redirected? Click this link to go to the dashboard."
-msgstr "¿No se redirige automáticamente? Haga clic en este enlace para ir al panel de control."
+#~ msgid "Not automatically redirected? Click this link to go to the dashboard."
+#~ msgstr "¿No se redirige automáticamente? Haga clic en este enlace para ir al panel de control."
 
 msgid "Notes"
 msgstr "Notas"
@@ -1134,8 +1143,11 @@ msgstr "Eliminar"
 msgid "Remove Conversion tracking"
 msgstr "Eliminar seguimiento de conversión"
 
-msgid "Request another link."
-msgstr "Solicitar otro enlace."
+#~ msgid "Request another link."
+#~ msgstr "Solicitar otro enlace."
+
+msgid "Return"
+msgstr ""
 
 msgid "Return to dashboard"
 msgstr "Volver al panel de control"
@@ -1275,8 +1287,8 @@ msgstr "Enviar"
 msgid "Success! Check your email."
 msgstr "¡Éxito! Revise su correo electrónico."
 
-msgid "Successfully logged in!"
-msgstr "¡Sesión iniciada con éxito!"
+#~ msgid "Successfully logged in!"
+#~ msgstr "¡Sesión iniciada con éxito!"
 
 msgid "Support"
 msgstr "Soporte"
@@ -1311,11 +1323,17 @@ msgstr "Se requiere la aceptación de los Términos y Condiciones"
 msgid "The <0>Basic Attention Token (BAT)</0> is Brave’s native crypto token. Brave Browser users who opt into <1>Brave Rewards</1> can earn BAT just for opting into viewing ads from the Brave Ads network. Earners can hold BAT like any other crypto asset, trade it, cash it in, or even donate it to their favorite creators."
 msgstr "El <0>Basic Attention Token (BAT)</0> es el token criptográfico nativo de Brave. Los usuarios del navegador Brave que opten por <1>Brave Rewards</1> pueden ganar BAT sólo por ver anuncios de la red Brave Ads. Los ganadores pueden conservar el BAT como cualquier otro criptoactivo, comerciar con él, canjearlo o incluso donarlo a sus creadores favoritos."
 
+msgid "The campaign will likely stop running before the end date provided due to budget constraints."
+msgstr ""
+
 msgid "The current value for this metric may be an underestimate."
 msgstr "El valor actual de esta métrica puede ser una subestimación."
 
 msgid "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
 msgstr "Los siguientes parámetros de cadena de consulta se agregarán a las URL de su página de destino. Esto le permitirá realizar un seguimiento del rendimiento de sus anuncios."
+
+msgid "The magic link you have requested has either expired or has already been used. Please return to the login page and try again."
+msgstr ""
 
 msgid "The username or password did not match our records."
 msgstr "El nombre de usuario o la contraseña no coincidieron con nuestros registros."
@@ -1383,8 +1401,11 @@ msgstr "No se puede cargar el anuncio"
 msgid "Unable to load reporting details for campaign: {0}"
 msgstr "No se pueden cargar los detalles de los informes de la campaña: {0}"
 
-msgid "Unable to login, link has expired or has already been used."
-msgstr "No se puede iniciar sesión, el enlace ha caducado o ya se ha utilizado."
+#~ msgid "Unable to login, link has expired or has already been used."
+#~ msgstr "No se puede iniciar sesión, el enlace ha caducado o ya se ha utilizado."
+
+msgid "Unable to login."
+msgstr ""
 
 msgid "Unable to register your organization at this time. Please try again later."
 msgstr "No se puede registrar su organización en este momento. Por favor, inténtelo de nuevo más tarde."
@@ -1511,6 +1532,9 @@ msgstr "Sí"
 
 msgid "You are attempting to create a new keypair, this will replace any of your account’s existing keypairs. Please note, previous keypairs cannot be retrieved or used once replaced."
 msgstr "Está intentando crear un nuevo par de claves, que reemplazará cualquiera de los pares de claves existentes de su cuenta. Tenga en cuenta que los pares de claves anteriores no se pueden recuperar ni utilizar una vez reemplazados."
+
+msgid "You are logging into the Brave Ads Manager Dashboard."
+msgstr ""
 
 msgid "You have {0} errors that must be fixed before submitting."
 msgstr "Tiene {0} errores que deben corregirse antes de enviar."

--- a/src/locales/pt.po
+++ b/src/locales/pt.po
@@ -336,6 +336,9 @@ msgstr ""
 msgid "Check your brand's eligibility"
 msgstr ""
 
+msgid "Check your spam folder or <0>return to the login page</0> to try again."
+msgstr ""
+
 msgid "Choose"
 msgstr "Escolher"
 
@@ -356,6 +359,9 @@ msgstr "Clique Aqui!"
 
 msgid "Click on the secure login link in the email to access your Brave Ads account."
 msgstr "Clique no link seguro de login no seu e-mail para acessar sua conta dos Anúncios Brave."
+
+msgid "Click the continue button below to complete the login process."
+msgstr ""
 
 msgid "Click Through Rate"
 msgstr "Taxa de Cliques"
@@ -558,8 +564,11 @@ msgstr "O domínio não deve conter espaços em branco"
 msgid "Domain to advertise"
 msgstr "Domínio para anunciar"
 
-msgid "Don’t see the email? Check your spam folder or <0>try again.</0>"
-msgstr "Não recebeu o e-mail? Verifique sua pasta de spam ou <0>tente novamente.</0>"
+msgid "Don’t see the email?"
+msgstr ""
+
+#~ msgid "Don’t see the email? Check your spam folder or <0>try again.</0>"
+#~ msgstr "Não recebeu o e-mail? Verifique sua pasta de spam ou <0>tente novamente.</0>"
 
 msgid "Download Report"
 msgstr "Baixar Relatório"
@@ -855,8 +864,8 @@ msgstr "Entrar"
 msgid "Log into your Brave Ads account"
 msgstr "Faça login em sua conta dos Anúncios Brave"
 
-msgid "Logging in"
-msgstr "Fazendo login"
+#~ msgid "Logging in"
+#~ msgstr "Fazendo login"
 
 msgid "Logout"
 msgstr "Sair"
@@ -951,8 +960,8 @@ msgstr "Nenhum anúncio anterior disponível"
 msgid "no session created"
 msgstr "nenhuma sessão criada"
 
-msgid "Not automatically redirected? Click this link to go to the dashboard."
-msgstr "Não foi redirecionado automaticamente? Clique neste link para acessar o dashboard."
+#~ msgid "Not automatically redirected? Click this link to go to the dashboard."
+#~ msgstr "Não foi redirecionado automaticamente? Clique neste link para acessar o dashboard."
 
 msgid "Notes"
 msgstr "Notas"
@@ -1134,8 +1143,11 @@ msgstr "Remover"
 msgid "Remove Conversion tracking"
 msgstr "Remover rastreamento de Conversão"
 
-msgid "Request another link."
-msgstr "Solicitar outro link."
+#~ msgid "Request another link."
+#~ msgstr "Solicitar outro link."
+
+msgid "Return"
+msgstr ""
 
 msgid "Return to dashboard"
 msgstr "Voltar ao dashboard"
@@ -1275,8 +1287,8 @@ msgstr "Enviar"
 msgid "Success! Check your email."
 msgstr "Sucesso! Verifique seu e-mail."
 
-msgid "Successfully logged in!"
-msgstr "Login realizado com sucesso!"
+#~ msgid "Successfully logged in!"
+#~ msgstr "Login realizado com sucesso!"
 
 msgid "Support"
 msgstr "Suporte"
@@ -1311,11 +1323,17 @@ msgstr "É necessário concordar com os Termos e Condições"
 msgid "The <0>Basic Attention Token (BAT)</0> is Brave’s native crypto token. Brave Browser users who opt into <1>Brave Rewards</1> can earn BAT just for opting into viewing ads from the Brave Ads network. Earners can hold BAT like any other crypto asset, trade it, cash it in, or even donate it to their favorite creators."
 msgstr "O <0>Basic Attention Token (BAT)</0> é a criptomoeda nativa do Brave. Usuários do navegador Brave que optam pelas <1>Recompensas Brave</1> podem ganhar BAT apenas por visualizar anúncios da rede dos Anúncios Brave. Os ganhadores podem manter o BAT como qualquer outro ativo cripto, trocá-lo, convertê-lo em dinheiro ou até mesmo doá-lo aos seus criadores favoritos."
 
+msgid "The campaign will likely stop running before the end date provided due to budget constraints."
+msgstr ""
+
 msgid "The current value for this metric may be an underestimate."
 msgstr "O valor atual para esta métrica pode ser uma subestimativa."
 
 msgid "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
 msgstr "Os seguintes parâmetros da string de consulta serão adicionados às URLs das suas páginas de destino. Isso permitirá que você acompanhe o desempenho dos seus anúncios."
+
+msgid "The magic link you have requested has either expired or has already been used. Please return to the login page and try again."
+msgstr ""
 
 msgid "The username or password did not match our records."
 msgstr "O nome de usuário ou senha não correspondem aos nossos registros."
@@ -1383,8 +1401,11 @@ msgstr "Não foi possível carregar o anúncio"
 msgid "Unable to load reporting details for campaign: {0}"
 msgstr "Não foi possível carregar os detalhes do relatório para a campanha: {0}"
 
-msgid "Unable to login, link has expired or has already been used."
-msgstr "Não foi possível fazer login, o link expirou ou já foi utilizado."
+#~ msgid "Unable to login, link has expired or has already been used."
+#~ msgstr "Não foi possível fazer login, o link expirou ou já foi utilizado."
+
+msgid "Unable to login."
+msgstr ""
 
 msgid "Unable to register your organization at this time. Please try again later."
 msgstr "No momento, não foi possível cadastrar sua organização. Por favor, tente novamente mais tarde."
@@ -1511,6 +1532,9 @@ msgstr "Sim"
 
 msgid "You are attempting to create a new keypair, this will replace any of your account’s existing keypairs. Please note, previous keypairs cannot be retrieved or used once replaced."
 msgstr "Você está tentando criar um novo par de chaves, isso substituirá qualquer um dos pares de chaves existentes na sua conta. Observe que os pares de chaves anteriores não podem ser recuperados ou usados uma vez que forem substituídos."
+
+msgid "You are logging into the Brave Ads Manager Dashboard."
+msgstr ""
 
 msgid "You have {0} errors that must be fixed before submitting."
 msgstr "Você tem {0} erros que devem ser corrigidos antes de enviar."

--- a/src/locales/test.po
+++ b/src/locales/test.po
@@ -331,6 +331,9 @@ msgstr ""
 msgid "Check your brand's eligibility"
 msgstr ""
 
+msgid "Check your spam folder or <0>return to the login page</0> to try again."
+msgstr ""
+
 msgid "Choose"
 msgstr ""
 
@@ -350,6 +353,9 @@ msgid "Click Here!"
 msgstr ""
 
 msgid "Click on the secure login link in the email to access your Brave Ads account."
+msgstr ""
+
+msgid "Click the continue button below to complete the login process."
 msgstr ""
 
 msgid "Click Through Rate"
@@ -553,8 +559,11 @@ msgstr ""
 msgid "Domain to advertise"
 msgstr ""
 
-msgid "Don’t see the email? Check your spam folder or <0>try again.</0>"
+msgid "Don’t see the email?"
 msgstr ""
+
+#~ msgid "Don’t see the email? Check your spam folder or <0>try again.</0>"
+#~ msgstr ""
 
 msgid "Download Report"
 msgstr ""
@@ -850,8 +859,8 @@ msgstr ""
 msgid "Log into your Brave Ads account"
 msgstr ""
 
-msgid "Logging in"
-msgstr ""
+#~ msgid "Logging in"
+#~ msgstr ""
 
 msgid "Logout"
 msgstr ""
@@ -946,8 +955,8 @@ msgstr ""
 msgid "no session created"
 msgstr ""
 
-msgid "Not automatically redirected? Click this link to go to the dashboard."
-msgstr ""
+#~ msgid "Not automatically redirected? Click this link to go to the dashboard."
+#~ msgstr ""
 
 msgid "Notes"
 msgstr ""
@@ -1129,7 +1138,10 @@ msgstr ""
 msgid "Remove Conversion tracking"
 msgstr ""
 
-msgid "Request another link."
+#~ msgid "Request another link."
+#~ msgstr ""
+
+msgid "Return"
 msgstr ""
 
 msgid "Return to dashboard"
@@ -1270,8 +1282,8 @@ msgstr ""
 msgid "Success! Check your email."
 msgstr ""
 
-msgid "Successfully logged in!"
-msgstr ""
+#~ msgid "Successfully logged in!"
+#~ msgstr ""
 
 msgid "Support"
 msgstr ""
@@ -1306,10 +1318,16 @@ msgstr ""
 msgid "The <0>Basic Attention Token (BAT)</0> is Brave’s native crypto token. Brave Browser users who opt into <1>Brave Rewards</1> can earn BAT just for opting into viewing ads from the Brave Ads network. Earners can hold BAT like any other crypto asset, trade it, cash it in, or even donate it to their favorite creators."
 msgstr ""
 
+msgid "The campaign will likely stop running before the end date provided due to budget constraints."
+msgstr ""
+
 msgid "The current value for this metric may be an underestimate."
 msgstr ""
 
 msgid "The following query string parameters will be added to your landing page URLs. This will allow you to track the performance of your ads."
+msgstr ""
+
+msgid "The magic link you have requested has either expired or has already been used. Please return to the login page and try again."
 msgstr ""
 
 msgid "The username or password did not match our records."
@@ -1378,7 +1396,10 @@ msgstr ""
 msgid "Unable to load reporting details for campaign: {0}"
 msgstr ""
 
-msgid "Unable to login, link has expired or has already been used."
+#~ msgid "Unable to login, link has expired or has already been used."
+#~ msgstr ""
+
+msgid "Unable to login."
 msgstr ""
 
 msgid "Unable to register your organization at this time. Please try again later."
@@ -1505,6 +1526,9 @@ msgid "Yes"
 msgstr ""
 
 msgid "You are attempting to create a new keypair, this will replace any of your account’s existing keypairs. Please note, previous keypairs cannot be retrieved or used once replaced."
+msgstr ""
+
+msgid "You are logging into the Brave Ads Manager Dashboard."
 msgstr ""
 
 msgid "You have {0} errors that must be fixed before submitting."


### PR DESCRIPTION
Missed translations from https://github.com/brave/ads-ui/pull/1302

ran `pnpm extract`