### PR TITLE
feat(search preview): don't show an estimated price

### DIFF
--- a/src/search/preview/SummaryPanel.tsx
+++ b/src/search/preview/SummaryPanel.tsx
@@ -10,7 +10,7 @@ import MonetizationOnOutlinedIcon from "@mui/icons-material/MonetizationOnOutlin
 import PercentIcon from "@mui/icons-material/Percent";
 import ArticleIcon from "@mui/icons-material/Article";
 import { SearchData } from "./data";
-import { formatUsd, formatWholeNumber } from "@/user/library/format";
+import { formatWholeNumber } from "@/user/library/format";
 
 function SummaryEntry({
   title,
@@ -92,11 +92,6 @@ export function SummaryPanel({ searchData }: Props) {
         icon={<MonetizationOnOutlinedIcon sx={{ color: "text.secondary" }} />}
         value={
           <Box display="flex" gap={1} alignItems="center">
-            <Box component="span" sx={{ textDecoration: "line-through" }}>
-              {formatUsd(searchData.estimates.trialBudget, {
-                dollarsOnly: true,
-              })}
-            </Box>
             <Box
               color="primary.contrastText"
               bgcolor="primary.main"


### PR DESCRIPTION
The price shown on this screen can be misleading as it is heavily estimated. Avoid this confusion.

## Before

<img width="422" alt="Screenshot 2024-08-20 at 09 04 17" src="https://github.com/user-attachments/assets/faa6ec33-a8d0-4205-9aad-3e6b3427c2fc">

## After
<img width="422" alt="Screenshot 2024-08-20 at 09 04 51" src="https://github.com/user-attachments/assets/b92e6426-0aae-4d06-9cd8-de06ce21acfe">

As requested by @lukaslevert / @jpschmetz 