### PR TITLE
fix(search landing page): get talking points off edge of screen

### DIFF
--- a/src/search/SearchLandingPage.tsx
+++ b/src/search/SearchLandingPage.tsx
@@ -22,7 +22,7 @@ export default function SearchLandingPage() {
           gap="50px"
           p={1}
         >
-          <Stack direction="column" spacing={3} maxWidth={650} alignSelf="top">
+          <Stack direction="column" spacing={3} maxWidth={750} alignSelf="top">
             <Typography variant="h1" color="white">
               <Trans>
                 Get incremental traffic with paid ads on the world's fastest

--- a/src/search/SearchTalkingPoints.tsx
+++ b/src/search/SearchTalkingPoints.tsx
@@ -21,7 +21,7 @@ export function SearchTalkingPoints() {
   return (
     <Stack
       direction={{ xs: "column", lg: "row" }}
-      justifyContent="space-between"
+      justifyContent={{ xs: "space-between", lg: "space-evenly" }}
       spacing={5}
       alignItems="center"
     >


### PR DESCRIPTION
Talking points are currently at edge of screen, lets fix that

![Screen Shot 2024-09-04 at 4 28 58 PM](https://github.com/user-attachments/assets/44d14ce6-4c7e-41a4-8a10-b17ab9f88d9c)
