### PR TITLE
feat(search-preview): tweaks to search preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
     "overrides": {
       "ws@>=8.0.0 <8.17.1": ">=8.17.1",
       "micromatch@<4.0.8": ">=4.0.8",
-      "path-to-regexp@>=0.2.0 <8.0.0": ">=8.0.0"
+      "path-to-regexp@>=0.2.0 <8.0.0": ">=8.0.0",
+      "dset@<3.1.4": ">=3.1.4"
     }
   },
   "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   ws@>=8.0.0 <8.17.1: '>=8.17.1'
   micromatch@<4.0.8: '>=4.0.8'
   path-to-regexp@>=0.2.0 <8.0.0: '>=8.0.0'
+  dset@<3.1.4: '>=3.1.4'
 
 importers:
 
@@ -2429,8 +2430,8 @@ packages:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
 
-  dset@3.1.3:
-    resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
+  dset@3.1.4:
+    resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
   easy-table@1.2.0:
@@ -5448,7 +5449,7 @@ snapshots:
       '@graphql-tools/utils': 9.2.1(graphql@16.9.0)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/fetch': 0.8.8
-      dset: 3.1.3
+      dset: 3.1.4
       extract-files: 11.0.0
       graphql: 16.9.0
       meros: 1.3.0(@types/node@20.13.0)
@@ -5746,7 +5747,7 @@ snapshots:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       cross-inspect: 1.0.0
-      dset: 3.1.3
+      dset: 3.1.4
       graphql: 16.9.0
       tslib: 2.6.2
 
@@ -7120,7 +7121,7 @@ snapshots:
 
   dotenv@16.4.5: {}
 
-  dset@3.1.3: {}
+  dset@3.1.4: {}
 
   easy-table@1.2.0:
     dependencies:

--- a/src/search/preview/CallToAction.tsx
+++ b/src/search/preview/CallToAction.tsx
@@ -3,9 +3,10 @@ import { Box, Button, Link, Typography } from "@mui/material";
 
 interface Props {
   domain: string;
+  hideBookMeeting: boolean;
 }
 
-export function CallToAction({ domain }: Props) {
+export function CallToAction({ domain, hideBookMeeting }: Props) {
   return (
     <Box
       marginBottom={1}
@@ -33,24 +34,28 @@ export function CallToAction({ domain }: Props) {
           by analyzing existing Google campaigns and matching them with keyword
           volumes from Brave Search.
         </Typography>
-        <Typography variant="body2" marginBottom={2}>
-          To view and manage all available ads and get started with Search Ads
-          from Brave, please book a meeting with an account manager.
-        </Typography>
+        {!hideBookMeeting && (
+          <Typography variant="body2" marginBottom={2}>
+            To view and manage all available ads and get started with Search Ads
+            from Brave, please book a meeting with an account manager.
+          </Typography>
+        )}
       </Box>
 
-      <Box minWidth="100px">
-        <Button
-          variant="contained"
-          color="primary"
-          component="a"
-          href="https://calendar.google.com/calendar/u/0/appointments/AcZssZ2sEAG3kPSlTKpGd48pYAa2zTd-QpI2L2ewxao="
-          target="_blank"
-          rel="noreferrer"
-        >
-          Book a Meeting
-        </Button>
-      </Box>
+      {!hideBookMeeting && (
+        <Box minWidth="100px">
+          <Button
+            variant="contained"
+            color="primary"
+            component="a"
+            href="https://calendar.google.com/calendar/u/0/appointments/AcZssZ2sEAG3kPSlTKpGd48pYAa2zTd-QpI2L2ewxao="
+            target="_blank"
+            rel="noreferrer"
+          >
+            Book a Meeting
+          </Button>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/search/preview/SearchPreviewPage.tsx
+++ b/src/search/preview/SearchPreviewPage.tsx
@@ -6,12 +6,15 @@ import { useLandingPageData } from "./data";
 import { SearchPreviewResults } from "./SearchPreviewResults";
 import { FullScreenProgress } from "@/components/FullScreenProgress";
 import { NoPreviewAvailable } from "./NoPreviewAvailable";
+import { extractOptionsFromUrlSlug } from "./options";
 
 /* eslint-disable lingui/no-unlocalized-strings */
 
 export default function SearchPreviewPage() {
   const { slug } = useParams<{ slug: string }>();
-  const { loading, data } = useLandingPageData(slug);
+  const options = extractOptionsFromUrlSlug(slug);
+
+  const { loading, data } = useLandingPageData(options.slug);
   return (
     <Box display="flex" height="100vh" width="100vw" flexDirection="row">
       <Navbar />
@@ -26,7 +29,11 @@ export default function SearchPreviewPage() {
       >
         <ErrorBoundary>
           {data ? (
-            <SearchPreviewResults data={data} />
+            <SearchPreviewResults
+              data={data}
+              hideBookMeeting={options.hideBookMeeting}
+              hideEstimates={options.hideEstimates}
+            />
           ) : loading ? (
             <FullScreenProgress />
           ) : (

--- a/src/search/preview/SearchPreviewResults.tsx
+++ b/src/search/preview/SearchPreviewResults.tsx
@@ -10,10 +10,15 @@ import { CallToAction } from "./CallToAction";
 
 interface Props {
   data: SearchData;
+  hideEstimates: boolean;
+  hideBookMeeting: boolean;
 }
 
-export function SearchPreviewResults({ data }: Props) {
-  // we don't actually use the basket
+export function SearchPreviewResults({
+  data,
+  hideBookMeeting,
+  hideEstimates,
+}: Props) {
   const basket = useBasket();
   return (
     <Box sx={{ marginLeft: "auto", marginRight: "auto", maxWidth: "1005px" }}>
@@ -24,7 +29,10 @@ export function SearchPreviewResults({ data }: Props) {
             height: "calc(100vh - 110px)",
           }}
         >
-          <CallToAction domain={data.countryDomain.domain} />
+          <CallToAction
+            domain={data.countryDomain.domain}
+            hideBookMeeting={hideBookMeeting}
+          />
 
           <LandingPageList
             landingPages={data.landingPages}
@@ -34,7 +42,7 @@ export function SearchPreviewResults({ data }: Props) {
         </CardContainer>
 
         <Box display="flex" flexDirection="column" gap={2}>
-          <SummaryPanel searchData={data} />
+          <SummaryPanel searchData={data} hideEstimates={hideEstimates} />
         </Box>
       </Box>
     </Box>

--- a/src/search/preview/SummaryPanel.tsx
+++ b/src/search/preview/SummaryPanel.tsx
@@ -44,9 +44,10 @@ function SummaryEntry({
 
 interface Props {
   searchData: SearchData;
+  hideEstimates: boolean;
 }
 
-export function SummaryPanel({ searchData }: Props) {
+export function SummaryPanel({ searchData, hideEstimates }: Props) {
   return (
     <CardContainer sx={{ width: 250 }}>
       <Typography variant="h2" marginBottom={1}>
@@ -68,53 +69,59 @@ export function SummaryPanel({ searchData }: Props) {
         icon={<ArticleIcon sx={{ color: "text.secondary" }} />}
       />
 
-      <Typography variant="h2" marginTop={3} marginBottom={1}>
-        Estimated weekly results
-      </Typography>
-      <SummaryEntry
-        title="Impressions"
-        value={formatWholeNumber(searchData.estimates.qpw.max)}
-        icon={<VisibilityOutlinedIcon sx={{ color: "text.secondary" }} />}
-      />
-      <SummaryEntry
-        title="Clicks"
-        value={formatWholeNumber(searchData.estimates.cpw.max)}
-        icon={<PanToolAltOutlinedIcon sx={{ color: "text.secondary" }} />}
-      />
-      <SummaryEntry
-        title="Click-through rate"
-        value="10%"
-        icon={<PercentIcon sx={{ color: "text.secondary" }} />}
-      />
+      {!hideEstimates && (
+        <>
+          <Typography variant="h2" marginTop={3} marginBottom={1}>
+            Estimated weekly results
+          </Typography>
+          <SummaryEntry
+            title="Impressions"
+            value={formatWholeNumber(searchData.estimates.qpw.max)}
+            icon={<VisibilityOutlinedIcon sx={{ color: "text.secondary" }} />}
+          />
+          <SummaryEntry
+            title="Clicks"
+            value={formatWholeNumber(searchData.estimates.cpw.max)}
+            icon={<PanToolAltOutlinedIcon sx={{ color: "text.secondary" }} />}
+          />
+          <SummaryEntry
+            title="Click-through rate"
+            value="10%"
+            icon={<PercentIcon sx={{ color: "text.secondary" }} />}
+          />
 
-      <SummaryEntry
-        title="Cost"
-        icon={<MonetizationOnOutlinedIcon sx={{ color: "text.secondary" }} />}
-        value={
-          <Box display="flex" gap={1} alignItems="center">
-            <Box
-              color="primary.contrastText"
-              bgcolor="primary.main"
-              padding={"2px 4px"}
-              borderRadius={1}
-              textTransform="uppercase"
-              whiteSpace="nowrap"
-              fontSize={"0.6rem"}
-            >
-              Trial Available
-            </Box>
-          </Box>
-        }
-      />
+          <SummaryEntry
+            title="Cost"
+            icon={
+              <MonetizationOnOutlinedIcon sx={{ color: "text.secondary" }} />
+            }
+            value={
+              <Box display="flex" gap={1} alignItems="center">
+                <Box
+                  color="primary.contrastText"
+                  bgcolor="primary.main"
+                  padding={"2px 4px"}
+                  borderRadius={1}
+                  textTransform="uppercase"
+                  whiteSpace="nowrap"
+                  fontSize={"0.6rem"}
+                >
+                  Trial Available
+                </Box>
+              </Box>
+            }
+          />
 
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        marginTop={2}
-        fontSize="0.6rem"
-      >
-        Estimates only. Actual volume may vary.
-      </Typography>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            marginTop={2}
+            fontSize="0.6rem"
+          >
+            Estimates only. Actual volume may vary.
+          </Typography>
+        </>
+      )}
     </CardContainer>
   );
 }

--- a/src/search/preview/options.test.ts
+++ b/src/search/preview/options.test.ts
@@ -8,14 +8,14 @@ it("should always pass through a slug with less that 15 characters", () => {
     slug: "12345678901234",
   });
 
-  expect(extractOptionsFromUrlSlug("banana12ol")).toMatchObject({
+  expect(extractOptionsFromUrlSlug("banana120l")).toMatchObject({
     hideBookMeeting: false,
     hideEstimates: false,
-    slug: "banana12ol",
+    slug: "banana120l",
   });
 });
 
-// if the slug is longer than 15 characters, parse an o and l from the suffix
+// if the slug is longer than 15 characters, parse an 0 and l from the suffix
 it.each([
   {
     input: "123456789012345",
@@ -52,7 +52,7 @@ it.each([
   {
     input: "123456789012345pppp",
     expected: {
-      // the non 'o' and 'l' as passed through
+      // the non '0' and 'l' as passed through
       slug: "123456789012345pppp",
       hideBookMeeting: false,
       hideEstimates: false,

--- a/src/search/preview/options.test.ts
+++ b/src/search/preview/options.test.ts
@@ -1,0 +1,73 @@
+import { it, expect } from "vitest";
+import { extractOptionsFromUrlSlug } from "./options";
+
+it("should always pass through a slug with less that 15 characters", () => {
+  expect(extractOptionsFromUrlSlug("12345678901234")).toMatchObject({
+    hideBookMeeting: false,
+    hideEstimates: false,
+    slug: "12345678901234",
+  });
+
+  expect(extractOptionsFromUrlSlug("banana12ol")).toMatchObject({
+    hideBookMeeting: false,
+    hideEstimates: false,
+    slug: "banana12ol",
+  });
+});
+
+// if the slug is longer than 15 characters, parse an o and l from the suffix
+it.each([
+  {
+    input: "123456789012345",
+    expected: {
+      slug: "123456789012345",
+      hideBookMeeting: false,
+      hideEstimates: false,
+    },
+  },
+  {
+    input: "1234567890123450",
+    expected: {
+      slug: "123456789012345",
+      hideBookMeeting: false,
+      hideEstimates: true,
+    },
+  },
+  {
+    input: "1234567890123450l",
+    expected: {
+      slug: "123456789012345",
+      hideBookMeeting: true,
+      hideEstimates: true,
+    },
+  },
+  {
+    input: "123456789012345l",
+    expected: {
+      slug: "123456789012345",
+      hideBookMeeting: true,
+      hideEstimates: false,
+    },
+  },
+  {
+    input: "123456789012345pppp",
+    expected: {
+      // the non 'o' and 'l' as passed through
+      slug: "123456789012345pppp",
+      hideBookMeeting: false,
+      hideEstimates: false,
+    },
+  },
+  {
+    input: "123456789012345p0p0p0p",
+    expected: {
+      slug: "123456789012345pppp",
+      hideBookMeeting: false,
+      hideEstimates: true,
+    },
+  },
+])("should process $input correctly", (condition) => {
+  expect(extractOptionsFromUrlSlug(condition.input)).toMatchObject(
+    condition.expected,
+  );
+});

--- a/src/search/preview/options.ts
+++ b/src/search/preview/options.ts
@@ -14,7 +14,7 @@ export function extractOptionsFromUrlSlug(urlSlug: string): Options {
 
   So:
   - assume that any new slugs that may be longer than 15 characters will not have look-alike letters
-  - we can therefore safely parse an o and l from the suffix if it's longer that 15 characters
+  - we can therefore safely parse an 0 and l from the suffix if it's longer that 15 characters
   */
 
   const baseSlug = urlSlug.substring(0, 15);

--- a/src/search/preview/options.ts
+++ b/src/search/preview/options.ts
@@ -9,7 +9,7 @@ export function extractOptionsFromUrlSlug(urlSlug: string): Options {
   Why this logic?
   
   Currently only ever create slugs that are 15 characters long, but we might want to change that
-  in the future. We don't use look-alike letters (e.g. "o" and "l") in the slugs nowadays, but we did 
+  in the future. We don't use look-alike letters (e.g. "0" and "l") in the slugs nowadays, but we did 
   in the past. 
 
   So:

--- a/src/search/preview/options.ts
+++ b/src/search/preview/options.ts
@@ -1,0 +1,16 @@
+interface Options {
+  slug: string;
+  hideEstimates: boolean;
+  hideBookMeeting: boolean;
+}
+
+export function extractOptionsFromUrlSlug(urlSlug: string): Options {
+  const slug = urlSlug.substring(0, 15);
+  const extra = urlSlug.substring(15);
+
+  return {
+    slug,
+    hideEstimates: extra.includes("e"),
+    hideBookMeeting: extra.includes("m"),
+  };
+}

--- a/src/search/preview/options.ts
+++ b/src/search/preview/options.ts
@@ -5,12 +5,26 @@ interface Options {
 }
 
 export function extractOptionsFromUrlSlug(urlSlug: string): Options {
-  const slug = urlSlug.substring(0, 15);
+  /*
+  Why this logic?
+  
+  Currently only ever create slugs that are 15 characters long, but we might want to change that
+  in the future. We don't use look-alike letters (e.g. "o" and "l") in the slugs nowadays, but we did 
+  in the past. 
+
+  So:
+  - assume that any new slugs that may be longer than 15 characters will not have look-alike letters
+  - we can therefore safely parse an o and l from the suffix if it's longer that 15 characters
+  */
+
+  const baseSlug = urlSlug.substring(0, 15);
   const extra = urlSlug.substring(15);
 
+  const filterdExtra = extra.replace(/[0l]/g, "");
+
   return {
-    slug,
-    hideEstimates: extra.includes("e"),
-    hideBookMeeting: extra.includes("m"),
+    slug: baseSlug + filterdExtra,
+    hideEstimates: extra.includes("0"),
+    hideBookMeeting: extra.includes("l"),
   };
 }


### PR DESCRIPTION
Permit hiding of estimates and book a meeting, whilst not necessarily making this obvious from the link.

So:
- append a string of characters to the slug including an "l" to hide the meeting invite link (think: l = link)
- append a string of characters to the slug including an "0" to hide the estimates (think: 0 = no numbers)

Although we currently use 15 characters for the slug, don't force this. But do assume that we'll continue avoiding lookalike characters if the slugs got > 15 chars.