### PR TITLE
fix(clone): conversions should only be postclick

### DIFF
--- a/src/form/fragmentUtil.ts
+++ b/src/form/fragmentUtil.ts
@@ -59,7 +59,7 @@ function createAdSetFromFragment(
     billingType: data.billingType ?? "cpm",
     conversions: (data.conversions ?? []).map((c) => ({
       observationWindow: c.observationWindow,
-      type: c.type,
+      type: "postclick",
       urlPattern: c.urlPattern,
     })),
     // eslint-disable-next-line lingui/no-unlocalized-strings

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -424,8 +424,11 @@ msgstr "Conversion Rate"
 #~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 #~ msgstr "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 
-msgid "Conversion type must be Post Click or Post View"
-msgstr "Conversion type must be Post Click or Post View"
+msgid "Conversion type must be Post Click"
+msgstr "Conversion type must be Post Click"
+
+#~ msgid "Conversion type must be Post Click or Post View"
+#~ msgstr "Conversion type must be Post Click or Post View"
 
 msgid "Conversion type required."
 msgstr "Conversion type required."

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -429,8 +429,11 @@ msgstr "Tasa de conversión"
 #~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 #~ msgstr "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 
-msgid "Conversion type must be Post Click or Post View"
-msgstr "El tipo de conversión debe ser Post Clic o Post Vista"
+msgid "Conversion type must be Post Click"
+msgstr ""
+
+#~ msgid "Conversion type must be Post Click or Post View"
+#~ msgstr "El tipo de conversión debe ser Post Clic o Post Vista"
 
 msgid "Conversion type required."
 msgstr "Se requiere el tipo de conversión."
@@ -1568,4 +1571,3 @@ msgstr "Su campaña de prueba será revisada por un Gerente de Cuenta. Agregue c
 
 msgid "Zip / Postal Code"
 msgstr "Código postal"
-

--- a/src/locales/pt.po
+++ b/src/locales/pt.po
@@ -429,8 +429,11 @@ msgstr "Taxa de Conversão"
 #~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 #~ msgstr "A geração de relatórios de conversão para os Anúncios Brave foi alterada para melhor manter a privacidade e a segurança do usuário. Campanhas com URLs de conversão que violem os requisitos recentemente esclarecidos para URLs de conversão serão automaticamente pausadas até que suas URLs sejam atualizadas. Por favor, reveja as diretrizes e tome as ações necessárias para evitar a interrupção da campanha. As novas diretrizes podem ser encontradas em <0/>"
 
-msgid "Conversion type must be Post Click or Post View"
-msgstr "O tipo de conversão deve ser Pós-Clique ou Pós-Visualização"
+msgid "Conversion type must be Post Click"
+msgstr ""
+
+#~ msgid "Conversion type must be Post Click or Post View"
+#~ msgstr "O tipo de conversão deve ser Pós-Clique ou Pós-Visualização"
 
 msgid "Conversion type required."
 msgstr "Tipo de conversão obrigatório."

--- a/src/locales/test.po
+++ b/src/locales/test.po
@@ -424,8 +424,11 @@ msgstr ""
 #~ msgid "Conversion reporting for Brave Ads has changed to better uphold user privacy and security. Campaigns with conversion URLs that violate the newly clarified requirements for conversion URLs will now automatically be paused until their URLs have been updated. Please review the guidelines and take any necessary action to prevent campaign disruption. New guidelines can be found at the <0/>"
 #~ msgstr ""
 
-msgid "Conversion type must be Post Click or Post View"
+msgid "Conversion type must be Post Click"
 msgstr ""
+
+#~ msgid "Conversion type must be Post Click or Post View"
+#~ msgstr ""
 
 msgid "Conversion type required."
 msgstr ""

--- a/src/validation/CampaignSchema.tsx
+++ b/src/validation/CampaignSchema.tsx
@@ -132,10 +132,7 @@ export const CampaignSchema = (prices: AdvertiserPrice[]) =>
                 )
                 .required(t`Observation window required.`),
               type: string()
-                .oneOf(
-                  ["postclick"],
-                  t`Conversion type must be Post Click or Post View`,
-                )
+                .oneOf(["postclick"], t`Conversion type must be Post Click`)
                 .required(t`Conversion type required.`),
             })
             .notRequired()


### PR DESCRIPTION
We have moved to only setup campaigns as postclick, however cloning a campaign can run into issues where this is not the case. Clone only as postclick.