### PR TITLE
chore(creative): remove passing a specific type to the server

### DIFF
--- a/src/components/Creatives/hooks/useSubmitCreative.tsx
+++ b/src/components/Creatives/hooks/useSubmitCreative.tsx
@@ -64,7 +64,7 @@ export function useSubmitCreative(props: { id: string }) {
       );
 
       const input = {
-        ..._.omit(valid, ["id", "targetUrlValid", "included"]),
+        ..._.omit(valid, ["id", "targetUrlValid", "included", "type"]),
         state: "under_review",
       };
 

--- a/src/user/library/index.test.ts
+++ b/src/user/library/index.test.ts
@@ -305,7 +305,7 @@ describe("edit form tests", () => {
       title: "valid",
       body: "valid",
     },
-    type: { code: "notification_v1_all" },
+    type: { code: "notification_all_v1" },
   };
 
   const ad: Partial<AdFragment> = {
@@ -407,7 +407,7 @@ describe("edit form tests", () => {
                 "state": "active",
                 "targetUrlValid": "",
                 "type": {
-                  "code": "notification_v1_all",
+                  "code": "notification_all_v1",
                 },
               },
               {
@@ -425,7 +425,7 @@ describe("edit form tests", () => {
                 "state": "active",
                 "targetUrlValid": "",
                 "type": {
-                  "code": "notification_v1_all",
+                  "code": "notification_all_v1",
                 },
               },
             ],
@@ -464,7 +464,7 @@ describe("edit form tests", () => {
                 "state": "active",
                 "targetUrlValid": "",
                 "type": {
-                  "code": "notification_v1_all",
+                  "code": "notification_all_v1",
                 },
               },
               {
@@ -482,7 +482,7 @@ describe("edit form tests", () => {
                 "state": "active",
                 "targetUrlValid": "",
                 "type": {
-                  "code": "notification_v1_all",
+                  "code": "notification_all_v1",
                 },
               },
             ],

--- a/src/user/library/index.ts
+++ b/src/user/library/index.ts
@@ -176,23 +176,25 @@ export function validCreativeFields<T extends GenericCreative>(
     targetUrlValid: "",
     state: c.state,
     type: { code: c.type.code },
-    payloadNotification: c.payloadNotification
-      ? {
-          title: c.payloadNotification.title,
-          body: c.payloadNotification.body,
-          targetUrl: c.payloadNotification.targetUrl,
-        }
-      : undefined,
-    payloadInlineContent: c.payloadInlineContent
-      ? {
-          ctaText: c.payloadInlineContent.ctaText,
-          description: c.payloadInlineContent.description,
-          dimensions: "900x750",
-          imageUrl: c.payloadInlineContent.imageUrl,
-          targetUrl: c.payloadInlineContent.targetUrl,
-          title: c.payloadInlineContent.title,
-        }
-      : undefined,
+    payloadNotification:
+      c.type.code === "notification_all_v1" && !!c.payloadNotification
+        ? {
+            title: c.payloadNotification.title,
+            body: c.payloadNotification.body,
+            targetUrl: c.payloadNotification.targetUrl,
+          }
+        : undefined,
+    payloadInlineContent:
+      c.type.code === "inline_content_all_v1" && !!c.payloadInlineContent
+        ? {
+            ctaText: c.payloadInlineContent.ctaText,
+            description: c.payloadInlineContent.description,
+            dimensions: "900x750",
+            imageUrl: c.payloadInlineContent.imageUrl,
+            targetUrl: c.payloadInlineContent.targetUrl,
+            title: c.payloadInlineContent.title,
+          }
+        : undefined,
   };
 }
 


### PR DESCRIPTION
While we still use the creative type code when pulling the campaign, we do not need it to pass to the server. This removes passing it to the server.