### PR TITLE
fix(creative): make sure type is not passed with button

### DIFF
--- a/src/components/Creatives/CreateCreativeButton.tsx
+++ b/src/components/Creatives/CreateCreativeButton.tsx
@@ -59,7 +59,7 @@ export function CreateCreativeButton({ index }: Props) {
         create({
           variables: {
             input: {
-              ..._.omit(newMeta.value, "included"),
+              ..._.omit(newMeta.value, ["included", "type"]),
               advertiserId: advertiser.id,
             },
           },


### PR DESCRIPTION
We removed type from create, did not realize that this also passed it