### PR TITLE
fix(creative): for news creatives, we still need dimensions

### DIFF
--- a/src/components/Creatives/CreateCreativeButton.tsx
+++ b/src/components/Creatives/CreateCreativeButton.tsx
@@ -50,6 +50,11 @@ export function CreateCreativeButton({ index }: Props) {
     ],
   });
 
+  const creative = validCreativeFields(
+    { ...newMeta.value, id: "" },
+    advertiser.id,
+  );
+
   return (
     <LoadingButton
       variant="contained"
@@ -59,8 +64,11 @@ export function CreateCreativeButton({ index }: Props) {
         create({
           variables: {
             input: {
-              ..._.omit(newMeta.value, ["included", "type"]),
               advertiserId: advertiser.id,
+              name: creative.name,
+              state: "under_review",
+              payloadNotification: creative.payloadNotification,
+              payloadInlineContent: creative.payloadInlineContent,
             },
           },
         });

--- a/src/validation/CreativeSchema.tsx
+++ b/src/validation/CreativeSchema.tsx
@@ -60,7 +60,9 @@ export const CreativeSchema = () =>
               .max(15, t`Call to action must be less than 15 characters`)
               .required(t`Call to action is required`),
             description: string().required(t`Ad description is required`),
-            dimensions: string().required(t`Ad image dimensions are required`),
+            dimensions: string()
+              .required(t`Ad image dimensions are required`)
+              .default("900x750"),
             imageUrl: string()
               .url(t`Image URL must be valid`)
               .required()


### PR DESCRIPTION
By removing pieces of initial creative, I also removed dimensions. Use existing function to get correct payload & dimensions