### PR TITLE
fix(validation): relax conversion type validation for backwards compatibility

### DIFF
--- a/src/validation/CampaignSchema.tsx
+++ b/src/validation/CampaignSchema.tsx
@@ -132,7 +132,10 @@ export const CampaignSchema = (prices: AdvertiserPrice[]) =>
                 )
                 .required(t`Observation window required.`),
               type: string()
-                .oneOf(["postclick"], t`Conversion type must be Post Click`)
+                .oneOf(
+                  ["postclick", "postview"],
+                  t`Conversion type must be Post Click`,
+                )
                 .required(t`Conversion type required.`),
             })
             .notRequired()


### PR DESCRIPTION
Resolves issue where old campaigns with this value can fail validation