### PR TITLE
fix: nominal balances should not show account balance modal

### DIFF
--- a/src/user/views/adsManager/views/advanced/components/campaign/fields/PaymentMethodField.tsx
+++ b/src/user/views/adsManager/views/advanced/components/campaign/fields/PaymentMethodField.tsx
@@ -21,7 +21,7 @@ export function PaymentMethodField() {
     return null;
   }
 
-  const balance = BigNumber(data?.advertiser?.accountBalance ?? "0");
+  const balance = BigNumber(data?.advertiser?.accountBalance ?? "0").dp(2);
   const amountOwed = useCallback(
     (balance: BigNumber) => {
       const budget = BigNumber(meta.value).minus(balance);


### PR DESCRIPTION
I had a balance of `0.00136`. We do not need to show account balance info ox in such cases.