### PR TITLE
chore: renovate + npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
 engine-strict = true
+
+# see https://pnpm.io/npmrc#verify-deps-before-run
+#  avoid wasting developer time due to forgetting to
+#  run pnpm install after an git pull
+verify-deps-before-run=install

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
     {
       "matchUpdateTypes": ["major"],
       "enabled": true
+    },
+    {
+      "matchDepTypes": ["overrides", "pnpm.overrides"],
+      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
1. update renovate config to not change `overrides`, as this forms useful documentation of which vulns we are specifically avoiding (this should autoclose https://github.com/brave/ads-ui/pull/1442)

2. add auto-install directive to .npmrc to avoid wasting dev time forgetting to call `pnpm install` after `git pull`