### PR TITLE
chore(renovate): adjust schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,7 @@
     ":semanticCommitTypeAll(chore)",
     "npm:unpublishSafe",
     "helpers:pinGitHubActionDigests",
-    "group:allNonMajor",
-    "schedule:weekends"
+    "group:allNonMajor"
   ],
   "labels": ["dependencies"],
   "postUpdateOptions": ["pnpmDedupe"],
@@ -17,8 +16,12 @@
       "enabled": true
     },
     {
-      "matchDepTypes": ["overrides", "pnpm.overrides"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["minor", "major", "patch"],
+      "schedule": ["* 0-8 * * *"]
+    },
+    {
+      "matchDepTypes": ["pnpm.overrides"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
It's very distracting to get renovate PRs during the working day, as we try to keep to "PR zero" to reduce the amount of wasted effort not yet delivering value. A constant stream of renovate PRs throughout the day also encourages ignoring them, a poor outcome.

Also, bring across from our other repos the clearer phrasing of the config to prevent updating of the override ranges.