### PR TITLE
fix: prevent long running news campaigns

### DIFF
--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -634,6 +634,9 @@ msgstr "End date is required"
 msgid "End date must be after start date"
 msgstr "End date must be after start date"
 
+msgid "End date must be before 1 July 2025"
+msgstr "End date must be before 1 July 2025"
+
 msgid "End Time"
 msgstr "End Time"
 

--- a/src/locales/es.po
+++ b/src/locales/es.po
@@ -639,6 +639,9 @@ msgstr "Se requiere fecha de finalización"
 msgid "End date must be after start date"
 msgstr "La fecha de finalización debe ser posterior a la fecha de inicio"
 
+msgid "End date must be before 1 July 2025"
+msgstr ""
+
 msgid "End Time"
 msgstr "Hora de finalización"
 
@@ -1646,4 +1649,3 @@ msgstr "Su campaña de prueba será revisada por un Gerente de Cuenta. Agregue c
 
 msgid "Zip / Postal Code"
 msgstr "Código postal"
-

--- a/src/locales/pt.po
+++ b/src/locales/pt.po
@@ -639,6 +639,9 @@ msgstr "A data final é obrigatória"
 msgid "End date must be after start date"
 msgstr "A data final deve ser após a data de início"
 
+msgid "End date must be before 1 July 2025"
+msgstr ""
+
 msgid "End Time"
 msgstr "Horário de término"
 
@@ -1646,4 +1649,3 @@ msgstr "Sua campanha de teste será revisada por um Gerente de Conta. Adicione a
 
 msgid "Zip / Postal Code"
 msgstr "CEP"
-

--- a/src/locales/test.po
+++ b/src/locales/test.po
@@ -634,6 +634,9 @@ msgstr ""
 msgid "End date must be after start date"
 msgstr ""
 
+msgid "End date must be before 1 July 2025"
+msgstr ""
+
 msgid "End Time"
 msgstr ""
 

--- a/src/validation/CampaignSchema.tsx
+++ b/src/validation/CampaignSchema.tsx
@@ -16,7 +16,7 @@ import {
   TrailingAsteriskRegex,
 } from "@/validation/regex";
 import { CreativeSchema } from "@/validation/CreativeSchema";
-import { CampaignFormat } from "@/graphql-client/graphql";
+import { CampaignFormat, PaymentType } from "@/graphql-client/graphql";
 import BigNumber from "bignumber.js";
 import { AdvertiserPrice } from "@/user/hooks/useAdvertiserWithPrices";
 import { Billing } from "@/user/views/adsManager/types";
@@ -25,6 +25,7 @@ import {
   uiLabelsForCampaignFormat,
 } from "@/util/campaign";
 import { t } from "@lingui/macro";
+import dayjs from "dayjs";
 
 export const MIN_PER_CAMPAIGN = 500;
 export const CampaignSchema = (prices: AdvertiserPrice[]) =>
@@ -65,7 +66,16 @@ export const CampaignSchema = (prices: AdvertiserPrice[]) =>
     }),
     endAt: date()
       .required(t`End date is required`)
-      .min(ref("startAt"), t`End date must be after start date`),
+      .min(ref("startAt"), t`End date must be after start date`)
+      .when(["format", "paymentType"], {
+        is: (f: CampaignFormat, p: PaymentType) =>
+          f === CampaignFormat.NewsDisplayAd && p !== PaymentType.Netsuite,
+        then: (schema) =>
+          schema.max(
+            dayjs("2025-07-01").toDate(),
+            t`End date must be before 1 July 2025`,
+          ),
+      }),
     geoTargets: array()
       .of(
         object().shape({


### PR DESCRIPTION
Reject any non-invoiced news campaigns that extend beyond 1 July 2025.