### PR TITLE
chore(renovate): stop running 'dedupe'

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,6 @@
     "group:allNonMajor"
   ],
   "labels": ["dependencies"],
-  "postUpdateOptions": ["pnpmDedupe"],
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Looking at the job logs, the `pnpm dedupe` command is failing which is preventing creation of PRs.

Remove this option: dedupe is pretty critical with `npm` to avoid many copies of dependencies of different versions, but `pnpm`'s resolution logic doesn't seem to suffer from this as much.

Also move renovate.json to .github subdir as is the usual convention.