### PR TITLE
fix: brave ledger fix for cloned campaigns

### DIFF
--- a/src/user/views/adsManager/views/advanced/components/form/EditCampaign.tsx
+++ b/src/user/views/adsManager/views/advanced/components/form/EditCampaign.tsx
@@ -93,7 +93,14 @@ export function EditCampaign() {
             `/user/main/complete/edit?referenceId=${data.adsManagerUpdateCampaign.id}`,
           );
         } else {
-          void createPaymentSession(data.adsManagerUpdateCampaign.id, payment);
+          if (payment === PaymentType.BraveLedger) {
+            void createPaymentSession(data.adsManagerUpdateCampaign.id);
+          } else {
+            void createPaymentSession(
+              data.adsManagerUpdateCampaign.id,
+              payment,
+            );
+          }
         }
       },
       onError() {


### PR DESCRIPTION
Fix for the case where cloned campaigns (or editing a campaign) caused an issue and prevented initializing the checkout process.