### PR TITLE
fix: `user/main/ads` fails with error

### DIFF
--- a/src/components/Creatives/CreativeList.tsx
+++ b/src/components/Creatives/CreativeList.tsx
@@ -11,7 +11,7 @@ import { CreativeStatusSwitch } from "@/components/Creatives/CreativeStatusSwitc
 import { CustomToolbar } from "@/components/Datagrid/CustomToolbar";
 import { useTrackMatomoPageView } from "@/hooks/useTrackWithMatomo";
 import { useLingui, Trans as ReactTrans } from "@lingui/react";
-import { Trans, msg } from "@lingui/macro";
+import { msg } from "@lingui/macro";
 
 import { MessageDescriptor } from "@lingui/core";
 import { useQuery } from "@apollo/client";
@@ -96,7 +96,7 @@ export function CreativeList() {
         />
       )}
       <CardContainer
-        header={<Trans>Ads</Trans>}
+        header={_(msg`Ads`)}
         sx={{
           flexGrow: 1,
           overflowX: "auto",


### PR DESCRIPTION
The complexity of translations hit us again, though this has apparently been broken since https://github.com/brave/ads-ui/pull/1507.

It seems the `Trans` macro doesn't apply the translations reliably, so use `_` instead.