### PR TITLE
ci: explicitly use frozen lockfile on install

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -21,7 +21,7 @@ jobs:
           node-version-file: ".node-version"
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - run: pnpm check
       - name: Build
         env:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: ".node-version"
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - run: pnpm check
       - name: Build
         env:

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: pnpm
-      - run: pnpm install
+      - run: pnpm install --frozen-lockfile
       - run: pnpm check
       - run: pnpm test


### PR DESCRIPTION
This makes no functional difference as  `--frozen-lockfile` is the [default](https://pnpm.io/cli/install#--frozen-lockfile) for `pnpm install` when CI is true [as it is on github actions](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables).

But make it explicit.