### PR TITLE
fix: landing page resizing improvement

### DIFF
--- a/src/auth/views/GetStartedLandingPage.tsx
+++ b/src/auth/views/GetStartedLandingPage.tsx
@@ -8,7 +8,7 @@ export function GetStartedLandingPage() {
   const isAuthenticated = useIsAuthenticated();
 
   return (
-    <Stack spacing={3}>
+    <Stack spacing={3} paddingX={{ xs: 1, xl: 0 }}>
       <Stack
         direction={{ xs: "column", md: "row" }}
         alignItems="center"
@@ -28,7 +28,15 @@ export function GetStartedLandingPage() {
             </Trans>
           </Typography>
         </Stack>
-        <img src={adFormats} height={287} width="100%" />
+        <img
+          src={adFormats}
+          style={{
+            height: 287,
+            width: "100%",
+            maxWidth: "600px",
+            objectFit: "contain",
+          }}
+        />
       </Stack>
 
       <Box display="flex" flexDirection="row" alignItems="baseline" gap="10px">

--- a/src/auth/views/components/FooterCTA.tsx
+++ b/src/auth/views/components/FooterCTA.tsx
@@ -4,7 +4,12 @@ import { Link as RouterLink } from "react-router-dom";
 
 export function FooterCTA() {
   return (
-    <Box display="flex" justifyContent="center" mt={5}>
+    <Box
+      display="flex"
+      justifyContent="center"
+      mt={5}
+      paddingX={{ xs: 1, lg: 0 }}
+    >
       <Stack maxWidth={1000} spacing={3}>
         <Typography variant="h4" textAlign="center" fontWeight={500}>
           <Trans>

--- a/src/auth/views/components/WhyUseBraveAds.tsx
+++ b/src/auth/views/components/WhyUseBraveAds.tsx
@@ -8,7 +8,14 @@ export function WhyUseBraveAds() {
   const { _ } = useLingui();
 
   return (
-    <Stack maxWidth={1200} spacing={3} mt={5} mb={3} flexGrow={1}>
+    <Stack
+      maxWidth={1200}
+      spacing={3}
+      mt={5}
+      mb={3}
+      flexGrow={1}
+      paddingX={{ xs: 2, md: 1, xl: 0 }}
+    >
       <Typography
         variant="h4"
         textAlign="center"


### PR DESCRIPTION
This fix intends to improve the landing page resizing on smaller screens. The main logo image now is not getting stretched and also added a small horizontal padding.

First image displays that under normal screen size there is no change, improvements are only visible in next three images on smaller screens.

<img width="757" height="432" alt="Screenshot 2025-09-11 at 9 31 20 PM" src="https://github.com/user-attachments/assets/b0252c3b-4080-496a-ada7-4de3e2efe8f6" />
<img width="481" height="799" alt="Screenshot 2025-09-11 at 9 32 07 PM" src="https://github.com/user-attachments/assets/65a3ad47-75b1-4a47-ad12-008cea1060c9" />
<img width="475" height="779" alt="Screenshot 2025-09-11 at 9 32 44 PM" src="https://github.com/user-attachments/assets/a15f9f19-f916-47dc-98db-814dcbda6e61" />
<img width="487" height="781" alt="Screenshot 2025-09-11 at 9 32 53 PM" src="https://github.com/user-attachments/assets/7e6872df-b5eb-4295-926e-3204f8e6c5e0" />
