### PR TITLE
chore(audit): temporarily ignore registry errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "format": "prettier --write .",
     "check:compile": "tsc",
     "check:format": "prettier --check .",
-    "check:audit": "pnpm audit",
+    "check:audit": "pnpm audit --ignore-registry-errors",
     "check:knip": "knip",
     "check:lint": "eslint src",
     "check": "pnpm run /^check:.*/",


### PR DESCRIPTION
See https://github.com/pnpm/pnpm/issues/11265 - pnpm audit calls fail (sometimes) with:

```
 ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint (at https://registry.npmjs.org/-/npm/v1/security/audits/quick) responded with 410: {"error":"This endpoint is being retired. Use the bulk advisory endpoint instead. See the following docs for more info: https://api-docs.npmjs.com/#tag/Audit"}. Fallback endpoint (at https://registry.npmjs.org/-/npm/v1/security/audits) responded with 410: {"error":"This endpoint is being retired. Use the bulk advisory endpoint instead. See the following docs for more info: https://api-docs.npmjs.com/#tag/Audit"}
```

This appears to be  an unannouced change made by github to the  npm registry backend, which breaks audit for both yarn classic and pnpm. I imagine they will see sense and revert quickly.