### PR TITLE
chore(audit): upgrade postcss

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,40 +5,38 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  ws@>=8.0.0 <8.17.1: '>=8.17.1'
-  micromatch@<4.0.8: '>=4.0.8'
-  dset@<3.1.4: '>=3.1.4'
-  path-to-regexp@>=0.2.0 <1.9.0: ^1.9.0
-  rollup@>=4.0.0 <4.22.4: '>=4.22.4'
-  cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
-  nanoid@<3.3.8: ^3.3.8
-  esbuild@<=0.24.2: '>=0.25.0'
   '@babel/helpers@<7.26.10': '>=7.26.10'
   '@babel/runtime@<7.26.10': '>=7.26.10'
-  brace-expansion@>=1.0.0 <=1.1.11: ^1.1.12
+  ajv@^6: ^6.14.0
+  ajv@^8 <8.18.0: '>=8.18.0'
+  brace-expansion@>=1.0.0 <=1.1.12: ^1.1.13
   brace-expansion@>=2.0.0 <=2.0.1: ^2.0.2
   brace-expansion@^5: '>=5.0.5'
-  tmp@<=0.2.3: '>=0.2.4'
-  js-yaml@<4.1.1: '>=4.1.1'
-  lodash-es@>=4.0.0 <=4.17.22: '>=4.17.23'
-  lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
-  ajv@^8 <8.18.0: '>=8.18.0'
-  ajv@^6: ^6.14.0
-  rollup@>=4.0.0 <4.59.0: '>=4.59.0'
-  minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
-  immutable@<4.3.8: '>=4.3.8'
-  flatted@<3.4.0: '>=3.4.0'
+  cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
+  dset@<3.1.4: '>=3.1.4'
+  esbuild@<=0.24.2: '>=0.25.0'
   flatted@<=3.4.1: '>=3.4.2'
-  yaml@>=1.0.0 <1.10.3: '>=1.10.3'
-  yaml@>=2.0.0 <2.8.3: '>=2.8.3'
+  immutable@<4.3.8: '>=4.3.8'
+  js-yaml@<4.1.1: '>=4.1.1'
+  lodash-es@<=4.17.23: '>=4.18.0'
+  lodash-es@>=4.0.0 <=4.17.22: '>=4.17.23'
+  lodash-es@>=4.0.0 <=4.17.23: '>=4.18.0'
+  lodash@<=4.17.23: '>=4.18.0'
+  lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
+  lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
+  micromatch@<4.0.8: '>=4.0.8'
+  minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
+  nanoid@<3.3.8: ^3.3.8
+  path-to-regexp@>=0.2.0 <1.9.0: ^1.9.0
   picomatch@<2.3.2: '>=2.3.2'
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
+  postcss@<8.5.10: ^8.5.10
+  rollup@>=4.0.0 <4.59.0: '>=4.59.0'
   smol-toml@<1.6.1: '>=1.6.1'
-  brace-expansion@<1.1.13: '>=1.1.13'
-  lodash-es@>=4.0.0 <=4.17.23: '>=4.18.0'
-  lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
-  lodash-es@<=4.17.23: '>=4.18.0'
-  lodash@<=4.17.23: '>=4.18.0'
+  tmp@<=0.2.3: '>=0.2.4'
+  ws@>=8.0.0 <8.17.1: '>=8.17.1'
+  yaml@>=1.0.0 <1.10.3: ^1.10.3
+  yaml@>=2.0.0 <2.8.3: ^2.8.3
 
 importers:
 
@@ -2001,8 +1999,8 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -2100,6 +2098,9 @@ packages:
   common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
@@ -3222,8 +3223,8 @@ packages:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3776,7 +3777,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: '>=2.8.3'
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3917,6 +3918,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    engines: {node: '>= 6'}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -5786,9 +5791,10 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  brace-expansion@2.0.3:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.5:
     dependencies:
@@ -5909,6 +5915,8 @@ snapshots:
 
   common-tags@1.8.2: {}
 
+  concat-map@0.0.1: {}
+
   constant-case@3.0.4:
     dependencies:
       no-case: 3.0.4
@@ -5925,7 +5933,7 @@ snapshots:
       import-fresh: 3.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 2.8.3
+      yaml: 1.10.3
 
   cosmiconfig@8.3.6(typescript@6.0.2):
     dependencies:
@@ -6887,7 +6895,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 1.1.14
 
   minimist@1.2.8: {}
 
@@ -7107,7 +7115,7 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -7679,7 +7687,7 @@ snapshots:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.10
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -7797,6 +7805,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@1.10.3: {}
 
   yaml@2.8.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,22 +1,19 @@
+blockExoticSubdeps: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude: []
-
-blockExoticSubdeps: true
 
 overrides:
   "@babel/helpers@<7.26.10": ">=7.26.10"
   "@babel/runtime@<7.26.10": ">=7.26.10"
   ajv@^6: ^6.14.0
   ajv@^8 <8.18.0: ">=8.18.0"
-  brace-expansion@^5: ">=5.0.5"
-  brace-expansion@<1.1.13: ">=1.1.13"
-  brace-expansion@>=1.0.0 <=1.1.11: ^1.1.12
+  brace-expansion@>=1.0.0 <=1.1.12: ^1.1.13
   brace-expansion@>=2.0.0 <=2.0.1: ^2.0.2
+  brace-expansion@^5: ">=5.0.5"
   cross-spawn@>=7.0.0 <7.0.5: ">=7.0.5"
   dset@<3.1.4: ">=3.1.4"
   esbuild@<=0.24.2: ">=0.25.0"
   flatted@<=3.4.1: ">=3.4.2"
-  flatted@<3.4.0: ">=3.4.0"
   immutable@<4.3.8: ">=4.3.8"
   js-yaml@<4.1.1: ">=4.1.1"
   lodash-es@<=4.17.23: ">=4.18.0"
@@ -31,12 +28,12 @@ overrides:
   path-to-regexp@>=0.2.0 <1.9.0: ^1.9.0
   picomatch@<2.3.2: ">=2.3.2"
   picomatch@>=4.0.0 <4.0.4: ">=4.0.4"
-  rollup@>=4.0.0 <4.22.4: ">=4.22.4"
+  postcss@<8.5.10: "^8.5.10"
   rollup@>=4.0.0 <4.59.0: ">=4.59.0"
   smol-toml@<1.6.1: ">=1.6.1"
   tmp@<=0.2.3: ">=0.2.4"
   ws@>=8.0.0 <8.17.1: ">=8.17.1"
-  yaml@>=1.0.0 <1.10.3: ">=1.10.3"
-  yaml@>=2.0.0 <2.8.3: ">=2.8.3"
+  yaml@>=1.0.0 <1.10.3: "^1.10.3"
+  yaml@>=2.0.0 <2.8.3: "^2.8.3"
 
 verifyDepsBeforeRun: install


### PR DESCRIPTION
to address:

```
│ ┌─────────────────────┬────────────────────────────────────────────────────────┐
│ │ moderate            │ PostCSS has XSS via Unescaped </style> in its CSS      │
│ │                     │ Stringify Output                                       │
│ ├─────────────────────┼────────────────────────────────────────────────────────┤
│ │ Package             │ postcss                                                │
│ ├─────────────────────┼────────────────────────────────────────────────────────┤
│ │ Vulnerable versions │ <8.5.10                                                │
│ ├─────────────────────┼────────────────────────────────────────────────────────┤
│ │ Patched versions    │ >=8.5.10                                               │
│ ├─────────────────────┼────────────────────────────────────────────────────────┤
│ │ Paths               │ .>vite>postcss                                         │
│ ├─────────────────────┼────────────────────────────────────────────────────────┤
│ │ More info           │ https://github.com/advisories/GHSA-qx2v-qp2m-jg93      │
│ └─────────────────────┴────────────────────────────────────────────────────────┘
│ 1 vulnerabilities found
│ Severity: 1 moderate
```