### PR TITLE
chore(renovate): remove the schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,10 +13,6 @@
       "enabled": true
     },
     {
-      "matchUpdateTypes": ["minor", "major", "patch"],
-      "schedule": ["* 0-8 * * 1,4"]
-    },
-    {
       "matchDepTypes": ["pnpm.overrides", "pnpm-workspace.overrides"],
       "enabled": false
     }


### PR DESCRIPTION
There doesn't seem to be enough time in the schedule we had set for renovate to complete its work, and the changes batch up.

Remove the schedule: instead let's just only merge the "update all non-major dependencies" PRs when enough has built up for it to be worthwhile.