### PR TITLE
chore(audit): upgrade shell-quote

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,7 +6,8 @@ src/locales/*.js
 src/graphql-client/*.ts
 src/graphql/ads-serve.graphql.schema.json
 
-# npm and prettier fight over a EOF on these files, let npm win:
+# pnpm and prettier fight over a EOF on these files, let npm win:
 package.json
 package-lock.json
 pnpm-lock.yaml
+pnpm-workspace.yaml

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
   postcss@<8.5.10: ^8.5.10
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
+  shell-quote@>=1.1.0 <=1.8.3: ^1.8.4
   smol-toml@<1.6.1: '>=1.6.1'
   tmp@<=0.2.3: '>=0.2.4'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
@@ -3213,8 +3214,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.1:
-    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -4070,7 +4072,7 @@ snapshots:
       listr2: 10.2.1
       log-symbols: 7.0.1
       micromatch: 4.0.8
-      shell-quote: 1.8.1
+      shell-quote: 1.8.4
       string-env-interpolation: 1.0.1
       ts-log: 3.0.2
       tslib: 2.8.1
@@ -6857,7 +6859,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.1: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ allowBuilds:
 
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: []
+minimumReleaseAgeExclude: [ shell-quote@1.8.4 ]
 
 overrides:
   "@babel/helpers@<7.26.10": ">=7.26.10"
@@ -34,6 +34,7 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: ">=4.0.4"
   postcss@<8.5.10: "^8.5.10"
   rollup@>=4.0.0 <4.59.0: ">=4.59.0"
+  shell-quote@>=1.1.0 <=1.8.3: ^1.8.4
   smol-toml@<1.6.1: ">=1.6.1"
   tmp@<=0.2.3: ">=0.2.4"
   ws@>=8.0.0 <8.20.1: ">=8.20.1"


### PR DESCRIPTION
To resolve:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ critical            │ shell-quote quote() does not escape newlines in object │
│                     │ .op values                                             │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ shell-quote                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=1.1.0 <=1.8.3                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=1.8.4                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>shell-quote                     │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-w7jw-789q-3m8p      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 critical
```