### PR TITLE
chore(renovate): temporarily disable npm package updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,11 @@
     {
       "matchDepTypes": ["pnpm.overrides", "pnpm-workspace.overrides"],
       "enabled": false
+    },
+    {
+      "description": "Since running pnpm to generate the lockfile currently breaks renovate, just flag in the dashboard when npm deps need updates",
+      "matchDatasources": ["npm"],
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
As this is breaking all renovate updates due to memory issues. See https://github.com/brave/ads-serve/pull/5808.