### PR TITLE
ci: upgrade pnpm and re-enable renovate npm checks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,11 +15,6 @@
     {
       "matchDepTypes": ["pnpm.overrides", "pnpm-workspace.overrides"],
       "enabled": false
-    },
-    {
-      "description": "Since running pnpm to generate the lockfile currently breaks renovate, just flag in the dashboard when npm deps need updates",
-      "matchDatasources": ["npm"],
-      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -101,5 +101,5 @@
       "eslint --cache --no-warn-ignored"
     ]
   },
-  "packageManager": "pnpm@11.7.0+sha512.19cc852c120c7125760f2443ee6be0ca5b40f9f50598de1a09a1f177503e010e57c23c77646e01e761de59bf874fb22a3398c33ab9691fc13eb946b6f0f4d620"
+  "packageManager": "pnpm@11.11.0"
 }


### PR DESCRIPTION
[pnpm v11.11](https://github.com/pnpm/pnpm/releases/tag/v11.11.0) includes [an update](https://github.com/pnpm/pnpm/pull/12870) intended to substantialy reduce cold-start memory usage, bringing it back to v10 levels.

This enables us to remove the temporary suspension on renovate npm package updates added in https://github.com/brave/ads-ui/pull/1725.