### PR TITLE
chore(audit): brace-expansion, js-yaml, shell-quote

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,15 @@ overrides:
   '@babel/runtime@<7.26.10': '>=7.26.10'
   ajv@^6: ^6.14.0
   ajv@^8 <8.18.0: '>=8.18.0'
-  brace-expansion@>=1.0.0 <=1.1.12: ^1.1.13
-  brace-expansion@>=2.0.0 <=2.0.1: ^2.0.2
-  brace-expansion@^5: '>=5.0.6'
+  brace-expansion@^1: ^1.1.16
+  brace-expansion@^2: ^2.0.2
+  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   dset@<3.1.4: '>=3.1.4'
   esbuild@<=0.24.2: '>=0.25.0'
   flatted@<=3.4.1: '>=3.4.2'
   immutable@<4.3.8: '>=4.3.8'
-  js-yaml@<4.1.1: '>=4.1.1'
-  js-yaml@<=4.1.1: ^4.1.2
+  js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   lodash-es@<=4.17.23: '>=4.18.0'
   lodash-es@>=4.0.0 <=4.17.22: '>=4.17.23'
   lodash-es@>=4.0.0 <=4.17.23: '>=4.18.0'
@@ -34,7 +33,7 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
   postcss@<8.5.10: ^8.5.10
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
-  shell-quote@>=1.1.0 <=1.8.3: ^1.8.4
+  shell-quote@<=1.8.4: ^1.8.5
   smol-toml@<1.6.1: '>=1.6.1'
   tmp@<=0.2.3: '>=0.2.4'
   ws@>=8.0.0 <8.20.1: '>=8.20.1'
@@ -1929,11 +1928,11 @@ packages:
   bignumber.js@11.1.5:
     resolution: {integrity: sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2719,10 +2718,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
-
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
@@ -3380,8 +3375,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -4272,7 +4267,7 @@ snapshots:
       listr2: 10.2.1
       log-symbols: 7.0.1
       micromatch: 4.0.8
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       string-env-interpolation: 1.0.1
       ts-log: 3.0.2
       tslib: 2.8.1
@@ -5663,12 +5658,12 @@ snapshots:
 
   bignumber.js@11.1.5: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5772,7 +5767,7 @@ snapshots:
   cosmiconfig@8.3.6(@typescript/typescript6@6.0.2):
     dependencies:
       import-fresh: 3.3.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -5782,7 +5777,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -6535,10 +6530,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
@@ -6718,11 +6709,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   ms@2.1.3: {}
 
@@ -7143,7 +7134,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ allowBuilds:
 
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: [ shell-quote@1.8.4, ws@8.21.0, js-yaml@4.1.2, '@babel/core@7.29.1' ]
+minimumReleaseAgeExclude: [ shell-quote@1.8.4 || 1.8.5, ws@8.21.0, js-yaml@4.1.2 || 4.3.0, '@babel/core@7.29.1', brace-expansion@1.1.16 || 5.0.7 ]
 
 overrides:
   '@babel/core@<=7.29.0': ^7.29.1
@@ -12,16 +12,15 @@ overrides:
   "@babel/runtime@<7.26.10": ">=7.26.10"
   ajv@^6: ^6.14.0
   ajv@^8 <8.18.0: ">=8.18.0"
-  brace-expansion@>=1.0.0 <=1.1.12: ^1.1.13
-  brace-expansion@>=2.0.0 <=2.0.1: ^2.0.2
-  brace-expansion@^5: ">=5.0.6"
+  brace-expansion@^1: ^1.1.16
+  brace-expansion@^2: ^2.0.2
+  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
   cross-spawn@>=7.0.0 <7.0.5: ">=7.0.5"
   dset@<3.1.4: ">=3.1.4"
   esbuild@<=0.24.2: ">=0.25.0"
   flatted@<=3.4.1: ">=3.4.2"
   immutable@<4.3.8: ">=4.3.8"
-  js-yaml@<4.1.1: ">=4.1.1"
-  js-yaml@<=4.1.1: ^4.1.2
+  js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   lodash-es@<=4.17.23: ">=4.18.0"
   lodash-es@>=4.0.0 <=4.17.22: ">=4.17.23"
   lodash-es@>=4.0.0 <=4.17.23: ">=4.18.0"
@@ -36,7 +35,7 @@ overrides:
   picomatch@>=4.0.0 <4.0.4: ">=4.0.4"
   postcss@<8.5.10: "^8.5.10"
   rollup@>=4.0.0 <4.59.0: ">=4.59.0"
-  shell-quote@>=1.1.0 <=1.8.3: ^1.8.4
+  shell-quote@<=1.8.4: ^1.8.5
   smol-toml@<1.6.1: ">=1.6.1"
   tmp@<=0.2.3: ">=0.2.4"
   ws@>=8.0.0 <8.20.1: ">=8.20.1"


### PR DESCRIPTION
To address:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via exponential-time expansion of │
│                     │ consecutive non-expanding {} groups                    │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <1.1.16                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=1.1.16                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-eslint/eslint-plugin>eslint>@eslint/config- │
│                     │ array>minimatch>brace-expansion                        │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>eslint>@eslint/        │
│                     │ eslintrc>minimatch>brace-expansion                     │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-                              │
│                     │ plugin>eslint>minimatch>brace-expansion                │
│                     │                                                        │
│                     │ ... Found 52 paths, run `pnpm why brace-expansion` for │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-3jxr-9vmj-r5cp      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via exponential-time expansion of │
│                     │ consecutive non-expanding {} groups                    │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=3.0.0 <5.0.7                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.0.7                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>graphql-config>minimatch>brace- │
│                     │ expansion                                              │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>graphql-               │
│                     │ config>minimatch>brace-expansion                       │
│                     │                                                        │
│                     │ .>typescript-eslint>@typescript-eslint/eslint-         │
│                     │ plugin>@typescript-eslint/parser>@typescript-eslint/   │
│                     │ typescript-estree>minimatch>brace-expansion            │
│                     │                                                        │
│                     │ ... Found 9 paths, run `pnpm why brace-expansion` for  │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-3jxr-9vmj-r5cp      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ js-yaml: YAML merge-key chains can force quadratic CPU │
│                     │ consumption                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ js-yaml                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=4.0.0 <4.3.0                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=4.3.0                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>cosmiconfig>js-yaml             │
│                     │                                                        │
│                     │ .>@graphql-codegen/cli>graphql-config>cosmiconfig>js-  │
│                     │ yaml                                                   │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>graphql-               │
│                     │ config>cosmiconfig>js-yaml                             │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-52cp-r559-cp3m      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ shell-quote: Quadratic-complexity Denial of Service in │
│                     │ `parse()` (CWE-407)                                    │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ shell-quote                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=1.8.4                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=1.8.5                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>shell-quote                     │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-395f-4hp3-45gv      │
└─────────────────────┴────────────────────────────────────────────────────────┘
4 vulnerabilities found
Severity: 4 high
```