### PR TITLE
chore(audit): upgrade brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "format": "prettier --write .",
     "check:compile": "tsc",
     "check:format": "prettier --check .",
-    "check:audit": "pnpm audit --ignore-registry-errors",
+    "check:audit": "pnpm audit",
     "check:knip": "knip",
     "check:lint": "eslint src",
     "check": "pnpm run /^check:.*/",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   ajv@^8 <8.18.0: '>=8.18.0'
   brace-expansion@^1: ^1.1.16
   brace-expansion@^2: ^2.0.2
-  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
+  brace-expansion@>=3.0.0 <5.0.8: ^5.0.8
   cross-spawn@>=7.0.0 <7.0.5: '>=7.0.5'
   dset@<3.1.4: '>=3.1.4'
   esbuild@<=0.24.2: '>=0.25.0'
@@ -1932,9 +1932,9 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5664,7 +5664,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6710,7 +6710,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,9 +2,15 @@ allowBuilds:
   "@parcel/watcher": true
   esbuild: true
 
+auditConfig:
+  ignoreGhsas: 
+    # this one has no fix available on the 1.x branch used by eslint v9
+    # ignoring since it is a DoS on a build-time tool (elint)
+    - GHSA-mh99-v99m-4gvg
+
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: [ ]
+minimumReleaseAgeExclude: [ brace-expansion@5.0.8 ]
 
 overrides:
   '@babel/core@<=7.29.0': ^7.29.1
@@ -14,7 +20,7 @@ overrides:
   ajv@^8 <8.18.0: ">=8.18.0"
   brace-expansion@^1: ^1.1.16
   brace-expansion@^2: ^2.0.2
-  brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
+  brace-expansion@>=3.0.0 <5.0.8: ^5.0.8
   cross-spawn@>=7.0.0 <7.0.5: ">=7.0.5"
   dset@<3.1.4: ">=3.1.4"
   esbuild@<=0.24.2: ">=0.25.0"


### PR DESCRIPTION
Note: no fix for this DoS is yet available on the 1.x branch, still used by eslint v9.  We still can't upgrade to eslint v10 due to incompatible plugins, so have ignored the audit error. Only used by eslint and a DoS, so potential impact is at build time only.

To address:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via unbounded expansion length    │
│                     │ causing an out-of-memory process crash                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=5.0.7                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.0.8                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>graphql-config>minimatch>brace- │
│                     │ expansion                                              │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>graphql-               │
│                     │ config>minimatch>brace-expansion                       │
│                     │                                                        │
│                     │ .>typescript-eslint>@typescript-eslint/eslint-         │
│                     │ plugin>@typescript-eslint/parser>@typescript-eslint/   │
│                     │ typescript-estree>minimatch>brace-expansion            │
│                     │                                                        │
│                     │ ... Found 61 paths, run `pnpm why brace-expansion` for │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-mh99-v99m-4gvg      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 high
```