### PR TITLE
fix: pnpm audit fix

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1923,11 +1923,11 @@ packages:
   bignumber.js@11.1.5:
     resolution: {integrity: sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2925,8 +2925,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3168,8 +3168,8 @@ packages:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.24:
+    resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -5652,12 +5652,12 @@ snapshots:
 
   bignumber.js@11.1.5: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6704,17 +6704,17 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   ms@2.1.3: {}
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -6907,9 +6907,9 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss@8.5.19:
+  postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7452,7 +7452,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.19
+      postcss: 8.5.24
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,14 +3,14 @@ allowBuilds:
   esbuild: true
 
 auditConfig:
-  ignoreGhsas: 
+  ignoreGhsas:
     # this one has no fix available on the 1.x branch used by eslint v9
     # ignoring since it is a DoS on a build-time tool (elint)
     - GHSA-mh99-v99m-4gvg
 
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: [ brace-expansion@5.0.8 ]
+minimumReleaseAgeExclude: [ brace-expansion@1.1.18 || 5.0.8 || 5.0.9, postcss@8.5.23 ]
 
 overrides:
   '@babel/core@<=7.29.0': ^7.29.1


### PR DESCRIPTION
Fix for:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via unbounded expansion length    │
│                     │ causing an out-of-memory process crash                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <1.1.17                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=1.1.17                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-eslint/eslint-plugin>eslint>@eslint/config- │
│                     │ array>minimatch>brace-expansion                        │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>eslint>@eslint/        │
│                     │ eslintrc>minimatch>brace-expansion                     │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-                              │
│                     │ plugin>eslint>minimatch>brace-expansion                │
│                     │                                                        │
│                     │ ... Found 52 paths, run `pnpm why brace-expansion` for │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-mh99-v99m-4gvg      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via unbounded expansion length    │
│                     │ causing an out-of-memory process crash                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=4.0.0 <5.0.8                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.0.8                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>graphql-config>minimatch>brace- │
│                     │ expansion                                              │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>graphql-               │
│                     │ config>minimatch>brace-expansion                       │
│                     │                                                        │
│                     │ .>typescript-eslint>@typescript-eslint/eslint-         │
│                     │ plugin>@typescript-eslint/parser>@typescript-eslint/   │
│                     │ typescript-estree>minimatch>brace-expansion            │
│                     │                                                        │
│                     │ ... Found 9 paths, run `pnpm why brace-expansion` for  │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-mh99-v99m-4gvg      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via unbounded intermediate        │
│                     │ arrays, bypassing the CVE-2026-14257 mitigation        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=4.0.0 <5.0.9                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.0.9                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>graphql-config>minimatch>brace- │
│                     │ expansion                                              │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>graphql-               │
│                     │ config>minimatch>brace-expansion                       │
│                     │                                                        │
│                     │ .>typescript-eslint>@typescript-eslint/eslint-         │
│                     │ plugin>@typescript-eslint/parser>@typescript-eslint/   │
│                     │ typescript-estree>minimatch>brace-expansion            │
│                     │                                                        │
│                     │ ... Found 9 paths, run `pnpm why brace-expansion` for  │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-rgw5-rvv9-x895      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via unbounded intermediate        │
│                     │ arrays, bypassing the CVE-2026-14257 mitigation        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <1.1.18                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=1.1.18                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-eslint/eslint-plugin>eslint>@eslint/config- │
│                     │ array>minimatch>brace-expansion                        │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>eslint>@eslint/        │
│                     │ eslintrc>minimatch>brace-expansion                     │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-                              │
│                     │ plugin>eslint>minimatch>brace-expansion                │
│                     │                                                        │
│                     │ ... Found 52 paths, run `pnpm why brace-expansion` for │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-rgw5-rvv9-x895      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ moderate            │ PostCSS: incomplete fix of GHSA-6g55-p6wh-862q —       │
│                     │ attacker-controlled sourceMappingURL reads arbitrary   │
│                     │ .map files when `from` is unset                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ postcss                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=8.5.22                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=8.5.23                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@vitejs/plugin-basic-ssl>vite>postcss                │
│                     │                                                        │
│                     │ .>@vitejs/plugin-react>vite>postcss                    │
│                     │                                                        │
│                     │ .>vite>postcss                                         │
│                     │                                                        │
│                     │ ... Found 6 paths, run `pnpm why postcss` for more     │
│                     │ information                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-fxqj-rqcc-2cmp      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```