### PR TITLE
fix: pnpm audit fix

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2713,8 +2713,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.0.2:
@@ -4204,7 +4204,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.1
       import-fresh: 3.3.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5761,7 +5761,7 @@ snapshots:
   cosmiconfig@8.3.6(@typescript/typescript6@6.0.2):
     dependencies:
       import-fresh: 3.3.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -5771,7 +5771,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -6526,7 +6526,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ auditConfig:
 
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: [ brace-expansion@1.1.18 || 5.0.8 || 5.0.9, postcss@8.5.23 ]
+minimumReleaseAgeExclude: [ brace-expansion@1.1.18 || 5.0.8 || 5.0.9, postcss@8.5.23, js-yaml@4.3.1 ]
 
 overrides:
   '@babel/core@<=7.29.0': ^7.29.1


### PR DESCRIPTION
Audit fix for:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ JS-YAML: Quadratic CPU consumption in !!omap           │
│                     │ resolution (3.x and 4.x) — CVE-2026-59870 fix not      │
│                     │ backported                                             │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ js-yaml                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=4.0.0 <4.3.1                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=4.3.1                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>cosmiconfig>js-yaml             │
│                     │                                                        │
│                     │ .>@graphql-codegen/cli>graphql-config>cosmiconfig>js-  │
│                     │ yaml                                                   │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>eslint>@eslint/        │
│                     │ eslintrc>js-yaml                                       │
│                     │                                                        │
│                     │ ... Found 20 paths, run `pnpm why js-yaml` for more    │
│                     │ information                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-5p4m-2wfm-xmqj      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```