### PR TITLE
fix: pnpm audit fix

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2928,8 +2928,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6716,7 +6716,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -6911,7 +6911,7 @@ snapshots:
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ auditConfig:
 
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: [ brace-expansion@1.1.18 || 5.0.8 || 5.0.9, postcss@8.5.23, js-yaml@4.3.1 ]
+minimumReleaseAgeExclude: [ brace-expansion@1.1.18 || 5.0.8 || 5.0.9, postcss@8.5.23, js-yaml@4.3.1, nanoid@3.3.17 ]
 
 overrides:
   '@babel/core@<=7.29.0': ^7.29.1


### PR DESCRIPTION
Pnpm audit fix for:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ nanoid: custom generators can loop indefinitely when   │
│                     │ size is zero                                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ nanoid                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <3.3.17                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.3.17                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@vitejs/plugin-basic-ssl>vite>postcss>nanoid         │
│                     │                                                        │
│                     │ .>@vitejs/plugin-react>vite>postcss>nanoid             │
│                     │                                                        │
│                     │ .>vite>postcss>nanoid                                  │
│                     │                                                        │
│                     │ ... Found 6 paths, run `pnpm why nanoid` for more      │
│                     │ information                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-2v37-7h3g-55p8      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```