### PR TITLE
chore(audit): upgrade `nanoid`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ overrides:
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
   micromatch@<4.0.8: '>=4.0.8'
   minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
-  nanoid@<3.3.8: ^3.3.8
+  nanoid@<3.3.18: ^3.3.18
   path-to-regexp@>=0.2.0 <1.9.0: ^1.9.0
   picomatch@<2.3.2: '>=2.3.2'
   picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
@@ -2908,8 +2908,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6674,7 +6674,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -6869,7 +6869,7 @@ snapshots:
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ auditConfig:
 
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: [ brace-expansion@1.1.18 || 5.0.8 || 5.0.9, postcss@8.5.23, js-yaml@4.3.1, nanoid@3.3.17 ]
+minimumReleaseAgeExclude: [ nanoid@3.3.18 ]
 
 overrides:
   '@babel/core@<=7.29.0': ^7.29.1
@@ -35,7 +35,7 @@ overrides:
   lodash@>=4.0.0 <=4.17.23: ">=4.18.0"
   micromatch@<4.0.8: ">=4.0.8"
   minimatch@>=10.0.0 <10.2.3: ">=10.2.3"
-  nanoid@<3.3.8: ^3.3.8
+  nanoid@<3.3.18: ^3.3.18
   path-to-regexp@>=0.2.0 <1.9.0: ^1.9.0
   picomatch@<2.3.2: ">=2.3.2"
   picomatch@>=4.0.0 <4.0.4: ">=4.0.4"


### PR DESCRIPTION
To address:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ nanoid: custom generators can loop indefinitely when   │
│                     │ size is zero                                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ nanoid                                                 │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <3.3.18                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.3.18                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@vitejs/plugin-basic-ssl>vite>postcss>nanoid         │
│                     │                                                        │
│                     │ .>@vitejs/plugin-react>vite>postcss>nanoid             │
│                     │                                                        │
│                     │ .>vite>postcss>nanoid                                  │
│                     │                                                        │
│                     │ ... Found 6 paths, run `pnpm why nanoid` for more      │
│                     │ information                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-2v37-7h3g-55p8      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 high
```