### PR TITLE
chore(audit): fix

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   esbuild@<=0.24.2: '>=0.25.0'
   flatted@<=3.4.1: '>=3.4.2'
   immutable@<4.3.8: '>=4.3.8'
-  js-yaml@>=4.0.0 <4.3.0: ^4.3.0
+  js-yaml@>=4.0.0 <4.3.2: ^4.3.2
   lodash-es@<=4.17.23: '>=4.18.0'
   lodash-es@>=4.0.0 <=4.17.22: '>=4.17.23'
   lodash-es@>=4.0.0 <=4.17.23: '>=4.18.0'
@@ -2726,8 +2726,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsesc@3.0.2:
@@ -4200,7 +4200,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.1
       import-fresh: 3.3.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5781,7 +5781,7 @@ snapshots:
   cosmiconfig@8.3.6(@typescript/typescript6@6.0.2):
     dependencies:
       import-fresh: 3.3.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -5791,7 +5791,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
@@ -6551,7 +6551,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ auditConfig:
 
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: [ ]
+minimumReleaseAgeExclude: []
 
 overrides:
   '@babel/core@<=7.29.0': ^7.29.1
@@ -26,7 +26,7 @@ overrides:
   esbuild@<=0.24.2: ">=0.25.0"
   flatted@<=3.4.1: ">=3.4.2"
   immutable@<4.3.8: ">=4.3.8"
-  js-yaml@>=4.0.0 <4.3.0: ^4.3.0
+  js-yaml@>=4.0.0 <4.3.2: ^4.3.2
   lodash-es@<=4.17.23: ">=4.18.0"
   lodash-es@>=4.0.0 <=4.17.22: ">=4.17.23"
   lodash-es@>=4.0.0 <=4.17.23: ">=4.18.0"


### PR DESCRIPTION
To address:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ js-yaml: maxTotalMergeKeys does not limit CPU use for  │
│                     │ empty merge sources                                    │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ js-yaml                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=4.0.0 <4.3.2                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=4.3.2                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>@graphql-codegen/cli>cosmiconfig>js-yaml             │
│                     │                                                        │
│                     │ .>@graphql-codegen/cli>graphql-config>cosmiconfig>js-  │
│                     │ yaml                                                   │
│                     │                                                        │
│                     │ .>@graphql-eslint/eslint-plugin>eslint>@eslint/        │
│                     │ eslintrc>js-yaml                                       │
│                     │                                                        │
│                     │ ... Found 20 paths, run `pnpm why js-yaml` for more    │
│                     │ information                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-2883-xcg3-v3hh      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 high
```